### PR TITLE
Improve nested fields support

### DIFF
--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -83,14 +83,9 @@ module GOVUKDesignSystemFormBuilder
     #   build_id('hint') #=> "person-name-hint"
     def build_id(id_type, delimiter = '-', replace = '_', segment: nil, attribute_name: nil, include_value: true)
       attribute = attribute_name || @attribute_name
-      value     = include_value && @value || nil
-      [
-        @object_name,
-        attribute,
-        segment,
-        value,
-        id_type
-      ]
+      value     = (include_value && @value) || nil
+
+      [@object_name, attribute, segment, value, id_type]
         .compact
         .join(delimiter)
         .parameterize

--- a/lib/govuk_design_system_formbuilder/base.rb
+++ b/lib/govuk_design_system_formbuilder/base.rb
@@ -17,6 +17,13 @@ module GOVUKDesignSystemFormBuilder
 
     # returns the id value used for the input
     #
+    # @param link_errors [Boolean] toggles whether or not the id will be generated in the normal
+    #   manner or replaced with the special error style when the attribute has an error on the
+    #   field. It's used when fields that have more than one input (dates, radios, checkboxes)
+    #   don't end up with duplicate (or no) ids by allowing a specific input to be targetted.
+    # @param segment [String] used when generating date field inputs ids, accepts +day+,
+    #   +month+ or +year+.
+    #
     # @note field_id is overridden so that the error summary can link to the
     #   correct element.
     #
@@ -28,11 +35,11 @@ module GOVUKDesignSystemFormBuilder
     # @return [String] the element's +id+
     # @see https://design-system.service.gov.uk/components/error-summary/#linking-from-the-error-summary-to-each-answer
     #   GOV.UK linking to elements from the error summary
-    def field_id(link_errors: false)
+    def field_id(link_errors: false, segment: nil)
       if link_errors && has_errors?
         build_id('field-error', include_value: false)
       else
-        build_id('field')
+        build_id('field', segment: segment)
       end
     end
 
@@ -74,12 +81,13 @@ module GOVUKDesignSystemFormBuilder
     #
     # @example
     #   build_id('hint') #=> "person-name-hint"
-    def build_id(id_type, delimiter = '-', replace = '_', attribute_name: nil, include_value: true)
+    def build_id(id_type, delimiter = '-', replace = '_', segment: nil, attribute_name: nil, include_value: true)
       attribute = attribute_name || @attribute_name
       value     = include_value && @value || nil
       [
         @object_name,
         attribute,
+        segment,
         value,
         id_type
       ]

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -125,10 +125,12 @@ module GOVUKDesignSystemFormBuilder
       # be able to link to the day field. Otherwise, generate IDs
       # in the normal fashion
       def id(segment, link_errors)
+        segment_identifier = SEGMENTS.fetch(segment)
+
         if has_errors? && link_errors
           field_id(link_errors: link_errors)
         else
-          [@object_name, @attribute_name, SEGMENTS.fetch(segment)].join("_")
+          field_id(segment: segment_identifier)
         end
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -14,9 +14,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:year_multiparam_attribute) { '1i' }
     let(:multiparam_attributes) { [day_multiparam_attribute, month_multiparam_attribute, year_multiparam_attribute] }
 
-    let(:day_identifier) { "person_born_on_#{day_multiparam_attribute}" }
-    let(:month_identifier) { "person_born_on_#{month_multiparam_attribute}" }
-    let(:year_identifier) { "person_born_on_#{year_multiparam_attribute}" }
+    let(:day_identifier) { "person-born-on-#{day_multiparam_attribute}-field" }
+    let(:month_identifier) { "person-born-on-#{month_multiparam_attribute}-field" }
+    let(:year_identifier) { "person-born-on-#{year_multiparam_attribute}-field" }
 
     let(:args) { [method, attribute] }
     subject { builder.send(*args) }

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -30,8 +30,21 @@ class Being
   end
 end
 
+class Pseudonym
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attribute :name, :string
+
+  validates :name,
+            presence: { message: 'Enter a pseudonym' },
+            length: { minimum: 3 }
+end
+
 class Person < Being
   include ActiveModel::Model
+
+  attr_accessor :pseudonym
 
   validates :name,
             presence: { message: 'Enter a name' },
@@ -42,6 +55,10 @@ class Person < Being
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }
+
+  def set_pseudonym(name)
+    self.pseudonym = Pseudonym.new(name)
+  end
 
   def self.valid_example
     new(


### PR DESCRIPTION
Nested fields should work in the intended manner most of the time, as we're wrapping Rails' built-in methods throughout, except for the following helpers:

* `#govuk_date_field`
* `#govuk_error_summary`

Date field was implemented differently as there are three separate inputs for a single field. The GOV.UK implementation uses three text inputs, but passes through the same parameter names as Rails' [`#date_select`](https://api.rubyonrails.org/v6.1.0/classes/ActionView/Helpers/DateHelper.html#method-i-date_select).

The error summary is entirely custom and uses the form builder's `#field_id` method, which should always return the same value for a field when there's an error present, regardless of whether it has a value or segment present.

The intent of this PR is to ensure that these helpers work correctly when the form contains nested objects.

* [x] standardise date input `id` generation
* [x] allow the error summary to take blocks containing custom errors (perhaps, just an idea that could be useful)
* [ ] make the error summary include errors originating in nested objects in the list of errors
