### PR TITLE
Change supported versions to latest Ruby releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/fde73b5dc9476197281b/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk_design_system_formbuilder/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk-formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.13.0-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Ruby-2.6.7%20%E2%95%B1%202.7.3%20%E2%95%B1%203.0.1-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Ruby-2.6.8%20%E2%95%B1%202.7.4%20%E2%95%B1%203.0.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 [![Ruby](https://img.shields.io/badge/Rails-6.0.4%20%E2%95%B1%206.1.3.2-E16D6D)](https://weblog.rubyonrails.org/releases/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("deep_merge", "~> 1.2.1")
 
   exact_rails_version = ENV.has_key?("RAILS_VERSION")
-  rails_version = ENV.fetch("RAILS_VERSION") { "6.0.3" }
+  rails_version = ENV.fetch("RAILS_VERSION") { "6.0.4" }
 
   %w(actionview activemodel activesupport).each do |lib|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -25,13 +25,13 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
-            | 3.0.1
+            | 3.0.2
         li
           span.govuk-tag.govuk-tag-red
-            | 2.7.3
+            | 2.7.4
         li
           span.govuk-tag.govuk-tag-red
-            | 2.6.7
+            | 2.6.8
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key

--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -4,7 +4,7 @@ module GOVUKDesignSystemFormBuilder
       # Attributes eases working with default and custom attributes by:
       # * deeply merging them so both the default (required) attributes are
       #   present
-      # * joins the arrays into strings to maintain Rails 6.0.3 compatibility
+      # * joins the arrays into strings to maintain Rails 6.0.* compatibility
       class Attributes
         # Rather than attempt to combine these attributes, just overwrite the
         # form internally-generated values with those that are passed in. This


### PR DESCRIPTION
There were some recent security fixes and version bumps across the supported version. They don't appear to be urgent or affect anything remotely close to this libary, so not worth rushing out a release or anything.
