### PR TITLE
Simplify the choice of text for legends and labels

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/label.rb
@@ -16,7 +16,7 @@ module GOVUKDesignSystemFormBuilder
 
         def html
           @checkbox.label(for: field_id(link_errors: @link_errors), class: label_classes) do
-            [localised_text(:label), @checkbox.text, @value].compact.first.to_s
+            label_content.to_s
           end
         end
 
@@ -24,6 +24,10 @@ module GOVUKDesignSystemFormBuilder
 
         def label_classes
           %w(label checkboxes__label).prefix(brand)
+        end
+
+        def label_content
+          [localised_text(:label), @checkbox.text, @value].find(&:presence)
         end
       end
     end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -50,7 +50,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def retrieve_text(option_text, hidden)
-        text = [option_text, localised_text(:label), @attribute_name.capitalize].compact.first
+        text = [option_text, localised_text(:label), @attribute_name.capitalize].find(&:presence)
 
         if hidden
           tag.span(text, class: %(#{brand}-visually-hidden))

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -45,7 +45,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def retrieve_text(supplied_text)
-        [supplied_text, localised_text(:legend), @attribute_name&.capitalize].compact.first
+        [supplied_text, localised_text(:legend), @attribute_name&.capitalize].find(&:presence)
       end
 
       def classes

--- a/spec/support/shared/shared_caption_examples.rb
+++ b/spec/support/shared/shared_caption_examples.rb
@@ -1,4 +1,4 @@
-shared_examples 'a field that supports captions' do
+shared_examples 'a field that supports captions' do |captioned_element|
   let(:caption_text) { 'Stage 3' }
   let(:caption_class) { %(govuk-caption-#{caption_size}) }
   let(:caption_size) { 'l' }
@@ -51,34 +51,50 @@ shared_examples 'a field that supports captions' do
       end
     end
   end
-end
 
-shared_examples 'a field that supports captions on the legend' do
-  it_behaves_like 'a field that supports captions' do
-    let(:caption_container_tag) { 'legend' }
-    let(:caption_container) { { legend: { text: legend_text, tag: caption_container_tag } } }
+  describe %(presence depending on the #{captioned_element}) do
+    context %(when the #{captioned_element} is nil) do
+      subject { builder.send(*args, caption: caption_args, captioned_element => nil) }
 
-    context 'when no legend is present but a caption is' do
-      subject { builder.send(*args, legend: nil, caption: caption_args) }
-
-      specify 'no caption should be rendered' do
+      specify 'no caption is rendered' do
         expect(subject).not_to have_tag('span', with: { class: caption_class })
+      end
+    end
+
+    context %(when the #{captioned_element} text is nil) do
+      subject { builder.send(*args, caption: caption_args, captioned_element => { text: nil }) }
+
+      # nil.presence is falsy so label will default to the attribute name so caption is rendered
+      specify 'the caption is rendered' do
+        expect(subject).to have_tag(captioned_element, with: { class: captioned_element_class })
+        expect(subject).to have_tag('span', with: { class: caption_class })
+      end
+    end
+
+    context %(when the #{captioned_element} text is an empty string) do
+      subject { builder.send(*args, caption: caption_args, captioned_element => { text: '' }) }
+
+      # ''.presence is also falsy so label will default to the attribute name so caption is rendered
+      specify 'the caption is rendered' do
+        expect(subject).to have_tag(captioned_element, with: { class: captioned_element_class })
+        expect(subject).to have_tag('span', with: { class: caption_class })
       end
     end
   end
 end
 
+shared_examples 'a field that supports captions on the legend' do
+  it_behaves_like('a field that supports captions', :legend) do
+    let(:caption_container_tag) { 'legend' }
+    let(:caption_container) { { legend: { text: legend_text, tag: caption_container_tag } } }
+    let(:captioned_element_class) { 'govuk-fieldset__legend' }
+  end
+end
+
 shared_examples 'a field that supports captions on the label' do
-  it_behaves_like 'a field that supports captions' do
+  it_behaves_like('a field that supports captions', :label) do
     let(:caption_container_tag) { 'label' }
     let(:caption_container) { { label: { text: label_text, size: 'm' } } }
-
-    context 'when no label is present but a caption is' do
-      subject { builder.send(*args, label: { text: '' }, caption: caption_args) }
-
-      specify 'no caption should be rendered' do
-        expect(subject).not_to have_tag('span', with: { class: caption_class })
-      end
-    end
+    let(:captioned_element_class) { 'govuk-label' }
   end
 end


### PR DESCRIPTION
Finding by presence is a more-descriptive approach than compacting the array and selecting the first remaining item.

It also gives us the opportunity to make the behaviour around label/legend rendering more intuitive when the key:

* is `nil`
* has `nil` text
* has text but it's empty (`""`)

Now, empty strings will fail Rails' `#presence` check and be treated like `nil`. This means that if you pass `#govuk_text_field(label: { text: "" })` the label will fall back to the localised or default value instead of rendering an empty `<label>` element.