### PR TITLE
Simplify MakeFile use

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 prefix=bundle exec
-guide_dir=cd guide;
+guide_dir=cd guide &&
 nanoc_default_port=3006
 nanoc_internal_checks=internal_links stale mixed_content
 nanoc_external_checks=external_links
@@ -16,17 +16,19 @@ rspec:
 npm-install:
 	${guide_dir} npm ci --silent
 nanoc-check-internal:
-	${guide_dir} ${prefix} nanoc check ${nanoc_internal_checks}
+	( ${guide_dir} ${prefix} nanoc check ${nanoc_internal_checks} )
 nanoc-check-external:
-	${guide_dir} ${prefix} nanoc check ${nanoc_external_checks}
+	( ${guide_dir} ${prefix} nanoc check ${nanoc_external_checks} )
 nanoc-check-all: build-guide
-	${guide_dir} ${prefix} nanoc check ${nanoc_internal_checks} ${nanoc_external_checks}
+	( ${guide_dir} ${prefix} nanoc check ${nanoc_internal_checks} ${nanoc_external_checks} )
 build:
 	${prefix} gem build govuk_design_system_formbuilder.gemspec
 build-guide: npm-install
-	${guide_dir} ${prefix} nanoc
+	( ${guide_dir} ${prefix} nanoc )
+view-guide: build-guide
+	( ${guide_dir} ${prefix} nanoc view --port ${nanoc_default_port} )
 watch-guide: npm-install
-	${guide_dir} ${prefix} nanoc live --port ${nanoc_default_port}
+	( ${guide_dir} ${prefix} nanoc live --port ${nanoc_default_port} )
 docs-server:
 	yard server --reload
 code-climate:


### PR DESCRIPTION
Simplify MakeFile use

1. use braces to isolate changing directory so it can
be used from root directory
2. add `view-guide` option to workaround error when
using `watch-guide`
```
RuntimeError: no acceptor (port is in use or requires root privileges)
  ... .rvm/gems/ruby-2.7.3/gems/eventmachine-1.2.7/lib/eventmachine.rb:531:in `start_tcp_server'
 ```