### PR TITLE
Enable error presenter injection

### DIFF
--- a/guide/content/introduction/error-handling.slim
+++ b/guide/content/introduction/error-handling.slim
@@ -44,4 +44,27 @@ p.govuk-body
       summary link should take the user to the first field. As the form builder
       doesn't know the order in which fields will be rendered, it must be specified.
 
+== render('/partials/example-fig.*',
+  caption: "Custom summary error presenter injection",
+  code: form_with_presenter_injection,
+  sample_data: departments_data_raw,
+  show_errors: :presenters,
+  hide_data: true,
+  hide_html_output: true) do
+
+  p.govuk-body
+    | Although the #{link_to('GDS design system recommends', 'https://design-system.service.gov.uk/components/error-summary/', target: '_blank').html_safe} that you use the same summary error message as that on the field there may be situations in which the summary level wording can be used to provide more or less context. Forms containing repeatable nested fields, for example, could use the summary message to clearly point to an attribute error instance.
+
+  p.govuk-body
+    | In such cases a custom error presenter that responds to "summary_error_for(attribute)"
+      can be supplied.
+
+    pre.example-input
+      code.highlight.language-ruby
+        | class ErrorPresenter
+            def summary_error_for(attribute)
+              "Custom summary error for \#{attribute}!"
+            end
+          end
+
 == render('/partials/related-info.*', links: error_handling_info)

--- a/guide/lib/examples/error_handling.rb
+++ b/guide/lib/examples/error_handling.rb
@@ -37,5 +37,24 @@ module Examples
         = f.govuk_phone_field :telephone_number, label: { text: "Phone number" }
       SNIPPET
     end
+
+    def form_with_presenter_injection
+      <<~SNIPPET
+        ruby:
+          # In controller typically
+          @error_presenter = ErrorPresenter.new
+
+        = f.govuk_error_summary(presenter: @error_presenter)
+
+        = f.govuk_text_field :name,
+          label: { text: 'Name' },
+          hint: { text: 'You can find it on your birth certificate' }
+
+        = f.govuk_date_field :date_of_birth,
+          date_of_birth: true,
+          legend: { text: 'Enter your date of birth' },
+          hint: { text: 'For example, 31 3 1980' }
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/error_presenter.rb
+++ b/guide/lib/helpers/error_presenter.rb
@@ -1,0 +1,5 @@
+class ErrorPresenter
+  def summary_error_for(attribute)
+    "Custom summary error for #{attribute}!"
+  end
+end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -89,6 +89,9 @@ class Person
     :telephone_number
   )
 
+  validates :name, presence: { message: %(Enter a name) }, on: :presenters
+  validates :date_of_birth, presence: { message: %(Enter a valid date of birth) }, on: :presenters
+
   validates :welcome_pack_reference_number, presence: { message: 'Enter the reference number you received in your welcome pack' }, on: :fields
   validates :welcome_pack_received_on, presence: { message: 'Enter the date you received your welcome pack' }, on: :fields
   validates :department_id, presence: { message: %(Select the department to which you've been assigned) }, on: :fields

--- a/guide/lib/setup/form_builder_objects.rb
+++ b/guide/lib/setup/form_builder_objects.rb
@@ -6,6 +6,8 @@ module Setup
         builder_with_field_errors
       when :base
         builder_with_base_errors
+      when :presenters
+        builder_with_presenter_errors
       else
         builder_without_errors
       end
@@ -23,6 +25,10 @@ module Setup
       GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_base_errors, helper, {})
     end
 
+    def builder_with_presenter_errors
+      GOVUKDesignSystemFormBuilder::FormBuilder.new(:person, object_with_presenter_errors, helper, {})
+    end
+
     def object
       Person.new
     end
@@ -33,6 +39,10 @@ module Setup
 
     def object_with_base_errors
       Person.new.tap { |p| p.valid?(:base_errors) }
+    end
+
+    def object_with_presenter_errors
+      Person.new.tap { |p| p.valid?(:presenters) }
     end
 
     def helper

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -959,8 +959,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_error_summary 'Uh-oh, spaghettios'
     #
     # @see https://design-system.service.gov.uk/components/error-summary/ GOV.UK error summary
-    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, order: nil, **kwargs, &block)
-      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, order: order, **kwargs, &block).html
+    def govuk_error_summary(title = config.default_error_summary_title, link_base_errors_to: nil, order: nil, presenter: nil, **kwargs, &block)
+      Elements::ErrorSummary.new(self, object_name, title, link_base_errors_to: link_base_errors_to, order: order, presenter: presenter, **kwargs, &block).html
     end
 
     # Generates a fieldset containing the contents of the block

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -442,5 +442,26 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
     end
+
+    context 'when a presenter is specified' do
+      subject { builder.send(*args, presenter: error_presenter.new) }
+
+      let(:error_presenter) do
+        Class.new do
+          def summary_error_for(attribute)
+            "#{attribute} is foobar!"
+          end
+        end
+      end
+
+      before { object.validate }
+
+      specify 'the presenter custom messages should be present in the error summary' do
+        expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+          expect(subject).to have_tag('li', text: 'favourite_colour is foobar!')
+          expect(subject).to have_tag('li', text: 'projects is foobar!')
+        end
+      end
+    end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -414,7 +414,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
-    context 'extra attributes' do
+    context 'when extra attributes are supplied' do
       before { object.valid? }
 
       it_behaves_like 'a field that allows extra HTML attributes to be set' do

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -446,20 +446,41 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     context 'when a presenter is specified' do
       subject { builder.send(*args, presenter: error_presenter.new) }
 
-      let(:error_presenter) do
-        Class.new do
-          def summary_error_for(attribute)
-            "#{attribute} is foobar!"
+      context 'with summary_error_for method' do
+        let(:error_presenter) do
+          Class.new do
+            def summary_error_for(attribute)
+              "#{attribute} is foobar!"
+            end
+          end
+        end
+
+        before { object.validate }
+
+        specify 'the presenter custom messages should be present in the error summary' do
+          expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+            expect(subject).to have_tag('li', text: 'favourite_colour is foobar!')
+            expect(subject).to have_tag('li', text: 'projects is foobar!')
           end
         end
       end
 
-      before { object.validate }
+      context 'without summary_error_for method' do
+        let(:error_presenter) do
+          Class.new do
+            def not_a_duck(attribute)
+              "#{attribute} is foobar!"
+            end
+          end
+        end
 
-      specify 'the presenter custom messages should be present in the error summary' do
-        expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
-          expect(subject).to have_tag('li', text: 'favourite_colour is foobar!')
-          expect(subject).to have_tag('li', text: 'projects is foobar!')
+        before { object.validate }
+
+        specify 'the default summary error messages should be present in the error summary' do
+          expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+            expect(subject).to have_tag('li', text: 'Choose a favourite colour')
+            expect(subject).to have_tag('li', text: 'Select at least one project')
+          end
         end
       end
     end


### PR DESCRIPTION
#### What
Enable summary error customisation

#### Why
Our use case currently requires us to present summary errors for multiple nested fields sets with wording to indicate the nested field set's _index and error_. This is an accessibility issue to some degree too.

**Example use case**
Users are able to add one or many nested objects, suppliers in this example, on a single form. The field level error is expected to display the "short" error message for the attribute while the summary message must display the error for the attribute as well as a plain english index of the nested field object. 

![Screenshot 2021-08-24 at 16 42 23](https://user-images.githubusercontent.com/7016425/130648046-b04d83cc-40b9-42da-afbc-618b9f1c2dc1.png)

_We also have nested fields within nested fields in the application which behave similarly._ 

#### How
We have a large set of validations that work in conjunction with a presenter (Decorator pattern) and i18n translations files to achieve this customised behaviour. The [presenter and dependencies can be seen here, for reference](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/tree/master/app/presenters/error_message).

This PR aims to enable us to inject this presenter to achieve the same behaviour using the govuk-formbuilder. This works by simply relying on duck-typing of an injected presenter and its `summary_error_for` method to retrieve the custom "ordinalized" message

