### PR TITLE
Improve the setup of error presenters

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
         @link_base_errors_to = link_base_errors_to
         @html_attributes     = kwargs
         @order               = order
-        @presenter           = setup_presenter(presenter)
+        @presenter           = presenter
       end
 
       def html
@@ -34,15 +34,15 @@ module GOVUKDesignSystemFormBuilder
 
       def list
         tag.ul(class: [%(#{brand}-list), summary_class('list')]) do
-          safe_join(@presenter.formatted_error_messages.map { |args| list_item(*args) })
+          safe_join(presenter.formatted_error_messages.map { |args| list_item(*args) })
         end
       end
 
       # If the provided @presenter is a class, instantiate it with the sorted
       # error_messages from our object. Otherwise (if it's any other object),
       # treat it like a presenter
-      def setup_presenter(presenter)
-        (presenter.is_a?(Class) ? presenter.new(error_messages) : presenter).tap do |p|
+      def presenter
+        (@presenter.is_a?(Class) ? @presenter.new(error_messages) : @presenter).tap do |p|
           fail(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages") unless
             p.respond_to?(:formatted_error_messages)
         end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
         @link_base_errors_to = link_base_errors_to
         @html_attributes     = kwargs
         @order               = order
-        @presenter           = presenter
+        @presenter           = setup_presenter(presenter)
       end
 
       def html
@@ -34,21 +34,18 @@ module GOVUKDesignSystemFormBuilder
 
       def list
         tag.ul(class: [%(#{brand}-list), summary_class('list')]) do
-          safe_join(presenter.formatted_error_messages.map { |args| list_item(*args) })
+          safe_join(@presenter.formatted_error_messages.map { |args| list_item(*args) })
         end
       end
 
       # If the provided @presenter is a class, instantiate it with the sorted
       # error_messages from our object. Otherwise (if it's any other object),
       # treat it like a presenter
-      def presenter
-        return @presenter.new(error_messages) if @presenter.is_a?(Class)
-
-        unless @presenter.respond_to?(:formatted_error_messages)
-          fail(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages")
+      def setup_presenter(presenter)
+        (presenter.is_a?(Class) ? presenter.new(error_messages) : presenter).tap do |p|
+          fail(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages") unless
+            p.respond_to?(:formatted_error_messages)
         end
-
-        @presenter
       end
 
       def error_messages

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -472,6 +472,15 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
         end
+
+        context "when the custom presenter is an class that doesn't implement #formatted_error_messages" do
+          let(:non_presenter) { OpenStruct }
+          subject { builder.send(*args, presenter: non_presenter) }
+
+          specify "fails with an appropriate error message" do
+            expect { subject }.to raise_error(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages")
+          end
+        end
       end
 
       context "as an instance" do
@@ -484,14 +493,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
             end
           end
         end
-      end
 
-      context "when the custom presenter doesn't implement #formatted_error_messages" do
-        let(:non_presenter) { "totally not a presenter" }
-        subject { builder.send(*args, presenter: non_presenter) }
+        context "when the custom presenter is an instance that doesn't implement #formatted_error_messages" do
+          let(:non_presenter) { "totally not a presenter" }
+          subject { builder.send(*args, presenter: non_presenter) }
 
-        specify "fails with an appropriate error message" do
-          expect { subject }.to raise_error(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages")
+          specify "fails with an appropriate error message" do
+            expect { subject }.to raise_error(ArgumentError, "error summary presenter doesn't implement #formatted_error_messages")
+          end
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -473,7 +473,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        context "when the custom presenter is an class that doesn't implement #formatted_error_messages" do
+        context "when the custom presenter is a class that doesn't implement #formatted_error_messages" do
           let(:non_presenter) { OpenStruct }
           subject { builder.send(*args, presenter: non_presenter) }
 


### PR DESCRIPTION
Now we're checking that both the custom class and instance implements `#formatted_error_messages` while simplifying the object setup.
