### PR TITLE
Make radio labels respect the `bold_labels:` setting

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -471,9 +471,9 @@ module GOVUKDesignSystemFormBuilder
     # @note Unlike the Rails +#collection_radio_buttons+ helper, this version can also insert
     #   hints per item in the collection by supplying a +:hint_method+
     #
-    # @note +:bold_labels+, while false by default, is set to true when a
-    #   +:hint_method+ is provided. This is done to make the label stand out more
-    #   from the hint.
+    # @note +:bold_labels+, is +nil+ (falsy) by default. When a +:hint_method+
+    #       is provided it will become +true+ to make the label stand out more
+    #       from the hint. The choice can be overridden with +true+ or +false+.
     #
     # @param attribute_name [Symbol] The name of the attribute
     # @param collection [Enumerable<Object>] Options to be added to the +select+ element
@@ -538,7 +538,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: false, classes: nil, include_hidden: config.default_collection_radio_buttons_include_hidden, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: nil, classes: nil, include_hidden: config.default_collection_radio_buttons_include_hidden, form_group: {}, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -21,7 +21,11 @@ module GOVUKDesignSystemFormBuilder
           @classes        = classes
           @form_group     = form_group
           @include_hidden = include_hidden
-          @bold_labels    = hint_method.present? || bold_labels
+          @bold_labels    = if bold_labels.nil?
+                              hint_method.present?
+                            else
+                              bold_labels
+                            end
         end
 
         def html

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -212,19 +212,41 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
       context 'bold labels' do
         let(:bold_label_class) { 'govuk-label--s' }
+        let(:bold_labels) { nil }
+        let(:hint_method) { nil }
 
-        context 'when bold labels are specified in the options' do
-          subject do
-            builder.send(*args.push(:description), bold_labels: true)
+        subject do
+          builder.send(*args.push(hint_method), bold_labels: bold_labels)
+        end
+
+        context 'when bold_labels: nil' do
+          context 'when a hint method is present' do
+            let(:hint_method) { :description }
+
+            specify 'labels should be bold to help them stand out from hints' do
+              expect(subject).to have_tag('label', with: { class: bold_label_class }, count: colours.size)
+            end
           end
+
+          context 'when no hint method is present' do
+            specify 'no labels should be set to bold' do
+              expect(subject).not_to have_tag('label', with: { class: bold_label_class })
+            end
+          end
+        end
+
+        context 'when bold_labels: true' do
+          let(:bold_labels) { true }
 
           specify 'all labels should be bold when hints are enabled' do
             expect(subject).to have_tag('label', with: { class: bold_label_class }, count: colours.size)
           end
         end
 
-        context 'when bold labels are not specified in the options' do
-          specify 'no labels should be bold when hints are enabled' do
+        context 'when bold_labels: false' do
+          let(:bold_labels) { false }
+
+          specify 'no labels should be set to bold' do
             expect(subject).not_to have_tag('label', with: { class: bold_label_class })
           end
         end


### PR DESCRIPTION
The previous behaviour was added very early on in the library's development and has remained unchanged since. It attempted to improve the contrast between the labels and hints by, when both are present, making the labels bold.

Unfortunately in doing so, it ignores the user preference when hints are present and non-bold labels are wanted.

This change updates the `bold_labels` argument default from `false` to `nil`. When left `nil`, the old behaviour is maintained, but now when set to either `true`/`false` the selected behaviour will take precedence.

Fixes #315
