### PR TITLE
Add support for Turbo

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -54,6 +54,12 @@ module GOVUKDesignSystemFormBuilder
   #   will check for on the bound object to see whether or not to try ordering the
   #   error messages
   #
+  # * +:default_error_summary_turbo_prefix+ is used to disable turbo/turbolinks from
+  #   handling clicks on links in the error summary. When it's a string (eg,
+  #   turbo), that will result in links with the attribute 'data-turbo=false'.
+  #   When nil, no data attribute will be added. Defaults to 'turbolinks' for
+  #   compatibilitiy's sake; this will change to 'turbo' when Rails 7 is released
+  #
   # * +:localisation_schema_fallback+ sets the prefix elements for the array
   #   used to build the localisation string. The final two elements are always
   #   are the object name and attribute name. The _special_ value +__context__+,
@@ -78,6 +84,7 @@ module GOVUKDesignSystemFormBuilder
     default_error_summary_title: 'There is a problem',
     default_error_summary_presenter: Presenters::ErrorSummaryPresenter,
     default_error_summary_error_order_method: nil,
+    default_error_summary_turbo_prefix: 'turbolinks',
     default_collection_check_boxes_include_hidden: true,
     default_collection_radio_buttons_include_hidden: true,
     default_submit_validate: false,

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -81,7 +81,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def list_item(attribute, message)
-        tag.li(link_to(message, same_page_link(field_id(attribute)), data: { turbolinks: false }))
+        tag.li(link_to(message, same_page_link(field_id(attribute)), **link_options))
       end
 
       def same_page_link(target)
@@ -128,6 +128,12 @@ module GOVUKDesignSystemFormBuilder
             labelledby: [summary_title_id.presence]
           }
         }
+      end
+
+      def link_options(turbo_prefix: config.default_error_summary_turbo_prefix)
+        return {} unless turbo_prefix
+
+        { data: { turbo_prefix => false } }
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_turbo_prefix_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_turbo_prefix_configuration_spec.rb
@@ -27,11 +27,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     end
 
     specify 'there should be no data attribute present on the error links' do
-      parsed_subject.css('a').map(&:attributes).each do |link_attrs|
-        link_attrs.each_key do |link_attr|
-          expect(link_attr).not_to start_with('data')
-        end
-      end
+      attributes = parsed_subject.css('a').map(&:attributes).flat_map(&:keys).uniq
+
+      expect(attributes).to contain_none_that(start_with('data'))
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_turbo_prefix_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/error_summary_turbo_prefix_configuration_spec.rb
@@ -1,0 +1,37 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  before { object.valid? }
+  subject { builder.govuk_error_summary }
+
+  describe 'changing the defualt prefix' do
+    let(:new_prefix) { 'turbo' }
+
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_error_summary_turbo_prefix = new_prefix
+      end
+    end
+
+    specify "there should be a data attribute matching the new prefix" do
+      expect(subject).to have_tag('a', with: { "data-#{new_prefix}" => "false" }, count: object.errors.size)
+    end
+  end
+
+  describe 'setting no prefix' do
+    before do
+      GOVUKDesignSystemFormBuilder.configure do |conf|
+        conf.default_error_summary_turbo_prefix = nil
+      end
+    end
+
+    specify 'there should be no data attribute present on the error links' do
+      parsed_subject.css('a').map(&:attributes).each do |link_attrs|
+        link_attrs.each_key do |link_attr|
+          expect(link_attr).not_to start_with('data')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -29,6 +29,8 @@ RSpec::Matchers.define(:have_no_leading_or_trailing_spaces) do
   # :nocov:
 end
 
+RSpec::Matchers.define_negated_matcher :contain_none_that, :include
+
 RSpec::Matchers.define(:have_no_double_spaces) do
   match { |string| string !~ %r(\s{2}) }
 


### PR DESCRIPTION
Allow turbolinks data attribute to be customised

Previously this was hardcoded to 'data-turbolinks' but now [Turbo](https://turbo.hotwired.dev/) is gaining traction it makes sense to add support. This approach will also allow other 'pushstate'/pjax tools to be used if necessary.

The new config item `default_error_summary_turbo_prefix` supports being set to either a string or nil.

When it's a string of 'turbo', every link in the error summary will have the attribute `data-turbo="false"`. The default value is 'turbolinks' so the library's behaviour won't change.

When nil no data attribute will be added to the link.
