### PR TITLE
Improve class building using a utility method

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -6,6 +6,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
       include Traits::Supplemental
+      include Traits::HTMLClasses
 
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
@@ -115,10 +116,12 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes(width)
-        %w(input date-input__input).prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-input--width-#{width}))
-          classes.push(%(#{brand}-input--error)) if has_errors?
-        end
+        build_classes(
+          %(input),
+          %(date-input__input),
+          %(input--width-#{width}),
+          %(input--error) => has_errors?,
+        ).prefix(brand)
       end
 
       # if the field has errors we want the govuk_error_summary to
@@ -148,7 +151,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def label_classes
-        %w(label date-input__label).prefix(brand)
+        build_classes(%(label), %(date-input__label)).prefix(brand)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/file.rb
+++ b/lib/govuk_design_system_formbuilder/elements/file.rb
@@ -8,6 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
       include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, hint:, label:, caption:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -40,9 +41,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        %w(file-upload).prefix(brand).tap do |c|
-          c.push(%(#{brand}-file-upload--error)) if has_errors?
-        end
+        build_classes(%(file-upload), %(file-upload--error) => has_errors?).prefix(brand)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -8,6 +8,7 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Label
       include Traits::Supplemental
       include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, hint:, label:, caption:, rows:, max_words:, max_chars:, threshold:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
@@ -42,10 +43,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        %w(textarea).prefix(brand).tap do |classes|
-          classes.push(%(#{brand}-textarea--error))    if has_errors?
-          classes.push(%(#{brand}-js-character-count)) if limit?
-        end
+        build_classes(%(textarea), %(textarea--error) => has_errors?, %(js-character-count) => limit?).prefix(brand)
       end
 
       def options
@@ -86,7 +84,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def limit_description_classes
-        %w(hint character-count__message).prefix(brand)
+        build_classes(%(hint), %(character-count__message)).prefix(brand)
       end
 
       def limit_description_id

--- a/lib/govuk_design_system_formbuilder/traits/html_classes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_classes.rb
@@ -1,0 +1,13 @@
+module GOVUKDesignSystemFormBuilder
+  module Traits
+    module HTMLClasses
+      # combine all the classes in *args with any keys from **kwargs
+      # where the value is true. Roughly based on the behaviour from
+      # Rails' class_names, but recreated here as that returns a string
+      # where we want an array.
+      def build_classes(*args, **kwargs)
+        (args + kwargs.map { |k, v| k if v }).compact
+      end
+    end
+  end
+end

--- a/lib/govuk_design_system_formbuilder/traits/html_classes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_classes.rb
@@ -6,7 +6,30 @@ module GOVUKDesignSystemFormBuilder
       # Rails' class_names, but recreated here as that returns a string
       # where we want an array.
       def build_classes(*args, **kwargs)
+        # FIXME: we need to handle the arguments differently for Ruby 2.6.x because
+        #        Ruby 2.7.0 brought the separation of positional and keyword
+        #        arguments.
+        #
+        #        This can be removed once support for 2.6.x is dropped.
+        #
+        #        https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
+        return ruby_2_6_build_classes_fallback(*args) if RUBY_VERSION < "2.7.0"
+
         (args + kwargs.map { |k, v| k if v }).compact
+      end
+
+    private
+
+      def ruby_2_6_build_classes_fallback(*args)
+        [].tap do |classes|
+          args.each do |arg|
+            if arg.is_a?(Hash)
+              arg.each { |k, v| classes.append(k) if v }
+            else
+              classes.append(arg)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This improvement follows on from a recent [PR on the components lib](/DFE-Digital/govuk-components/pull/264) where [Rails' class_names](https://github.com/rails/rails/pull/37918) was used to improve the building of lists of HTML classes.

Unfortunately it returns a space-separated string instead of an array - and the method it uses to actually build up the classes, `#build_tag_values`, is private, which makes utilsing it a bit of a pain.

Instead here we're implementing a minimal version of it called `#build_classes`. It uses more-or-less the same class-building strategy as `#build_tag_values` but is less flexible in terms of args it accepts.
