### PR TITLE
Allow error presenters to override link targets

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -80,8 +80,8 @@ module GOVUKDesignSystemFormBuilder
         config.default_error_summary_error_order_method
       end
 
-      def list_item(attribute, message)
-        tag.li(link_to(message, same_page_link(field_id(attribute)), **link_options))
+      def list_item(attribute, message, url = nil)
+        tag.li(link_to(message, url || same_page_link(field_id(attribute)), **link_options))
       end
 
       def same_page_link(target)

--- a/lib/govuk_design_system_formbuilder/presenters/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/presenters/error_summary.rb
@@ -19,9 +19,13 @@ module Presenters
     # passed into {GOVUKDesignSystemFormBuilder::Elements::ErrorSummary#list_item}.
     #
     # @return [Array<Array(Symbol, String)>] array of attribute and message arrays
+    # @return [Array<Array(Symbol, String, String)>] array of attribute, message and URL arrays.
     #
     # @example Output format given the input above:
     #   [[:attribute_one, "first error"], [:attribute_two, "third error"]]
+    #
+    # @example Output with hard-coded URLs
+    #   [[:attribute_one, "first error", "https://example.com/attribute-one"], [:attribute_two, "third error", "https://example.com/attribute-two"]]
     def formatted_error_messages
       @error_messages.map { |attribute, messages| [attribute, messages.first] }
     end

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -503,6 +503,28 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
       end
+
+      context "when the third item in the error messages array is present" do
+        let(:presenter_with_external_links) do
+          Class.new do
+            def initialize(error_messages)
+              @error_messages = error_messages
+            end
+
+            def formatted_error_messages
+              @error_messages.map { |attribute, messages| [attribute, messages.first, %(https://www.errors.com/#{attribute})] }
+            end
+          end
+        end
+
+        subject { builder.send(*args, presenter: presenter_with_external_links) }
+
+        specify "the third argument forms the hyperlink" do
+          object.errors.messages.transform_values(&:first).each do |attr, message|
+            expect(subject).to have_tag("a", with: { href: "https://www.errors.com/#{attr}" }, text: message)
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Most of the time we want to link to an error that's on the same page (and managed by the form builder itself) but there may be occasions where we need to do something a little more specialised, such as linking to something outside of the form builder or linking to another page entirely.

The format for #formatted_error_messages is an array of arrays that contain two items; the first is the attribute and the second is the corresponding error message.

Here we're implementing a optional third item that when set will form the error's link target. This will allow developers a greater level of customisation while keeping the library generic.

Refs #325
