### PR TITLE
Support the maxlength attribute when building the Date element

### DIFF
--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -63,4 +63,15 @@ section
         should be taken into account when displaying the data or using it for
         analysis.
 
+  == render('/partials/example-fig.*',
+    caption: 'Specifying client side length restrictions on date inputs with maxlength',
+    code: maxlength_enabled_field,
+    hide_html_output: true) do
+
+    p.govuk-body
+      | When desiring client side restrictions on the number of characters each
+        input requires, you can use the <code>maxlength_enabled</code> parameter.
+        This will default the day and month inputs to 2 characters and the year
+        input to 4 characters.
+
 == render('/partials/related-info.*', links: date_info)

--- a/guide/content/form-elements/date-field.slim
+++ b/guide/content/form-elements/date-field.slim
@@ -69,7 +69,7 @@ section
     hide_html_output: true) do
 
     p.govuk-body
-      | When desiring client side restrictions on the number of characters each
+      | To enable client side restrictions on the number of characters each
         input requires, you can use the <code>maxlength_enabled</code> parameter.
         This will default the day and month inputs to 2 characters and the year
         input to 4 characters.

--- a/guide/lib/examples/date.rb
+++ b/guide/lib/examples/date.rb
@@ -17,5 +17,14 @@ module Examples
           hint: { text: 'For example, 3 2014' }
       SNIPPET
     end
+
+    def maxlength_enabled_field
+      <<~SNIPPET
+        = f.govuk_date_field :date_of_trade,
+          maxlength_enabled: true,
+          legend: { text: 'When are you planning to trade the goods?' },
+          hint: { text: 'Use the format day, month, year, for example 27 3 2021' }
+      SNIPPET
+    end
   end
 end

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -912,6 +912,7 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param omit_day [Boolean] do not render a day input, only capture month and year
+    # @param maxlength_enabled [Boolean] adds maxlength attribute to day, month and year inputs (2, 2, and 4, respectively)
     # @param wildcards [Boolean] add an 'X' to the day and month patterns so users can add approximate dates
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
@@ -936,8 +937,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, form_group: {}, wildcards: false, **kwargs, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, form_group: form_group, wildcards: wildcards, **kwargs, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, form_group: {}, wildcards: false, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, maxlength_enabled: maxlength_enabled, form_group: form_group, wildcards: wildcards, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -56,33 +56,21 @@ module GOVUKDesignSystemFormBuilder
       def day
         return if omit_day?
 
-        if maxlength_enabled?
-          date_part(:day, width: 2, link_errors: true, maxlength: 2)
-        else
-          date_part(:day, width: 2, link_errors: true)
-        end
+        date_part(:day, width: 2, link_errors: true)
       end
 
       def month
-        if maxlength_enabled?
-          date_part(:month, width: 2, link_errors: omit_day?, maxlength: 2)
-        else
-          date_part(:month, width: 2, link_errors: omit_day?)
-        end
+        date_part(:month, width: 2, link_errors: omit_day?)
       end
 
       def year
-        if maxlength_enabled?
-          date_part(:year, width: 4, maxlength: 4)
-        else
-          date_part(:year, width: 4)
-        end
+        date_part(:year, width: 4)
       end
 
-      def date_part(segment, width:, link_errors: false, maxlength: nil)
+      def date_part(segment, width:, link_errors: false)
         tag.div(class: %(#{brand}-date-input__item)) do
           tag.div(class: %(#{brand}-form-group)) do
-            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment), maxlength)])
+            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment))])
           end
         end
       end
@@ -113,7 +101,7 @@ module GOVUKDesignSystemFormBuilder
         )
       end
 
-      def input(segment, link_errors, width, value, maxlength)
+      def input(segment, link_errors, width, value)
         tag.input(
           id: id(segment, link_errors),
           class: classes(width),
@@ -123,7 +111,7 @@ module GOVUKDesignSystemFormBuilder
           inputmode: 'numeric',
           value: value,
           autocomplete: date_of_birth_autocomplete_value(segment),
-          maxlength: maxlength,
+          maxlength: (width if maxlength_enabled?),
         )
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -11,17 +11,18 @@ module GOVUKDesignSystemFormBuilder
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @legend          = legend
-        @caption         = caption
-        @hint            = hint
-        @date_of_birth   = date_of_birth
-        @omit_day        = omit_day
-        @form_group      = form_group
-        @wildcards       = wildcards
-        @html_attributes = kwargs
+        @legend            = legend
+        @caption           = caption
+        @hint              = hint
+        @date_of_birth     = date_of_birth
+        @omit_day          = omit_day
+        @maxlength_enabled = maxlength_enabled
+        @form_group        = form_group
+        @wildcards         = wildcards
+        @html_attributes   = kwargs
       end
 
       def html
@@ -48,24 +49,40 @@ module GOVUKDesignSystemFormBuilder
         @omit_day
       end
 
+      def maxlength_enabled?
+        @maxlength_enabled
+      end
+
       def day
         return if omit_day?
 
-        date_part(:day, width: 2, link_errors: true)
+        if maxlength_enabled?
+          date_part(:day, width: 2, link_errors: true, maxlength: 2)
+        else
+          date_part(:day, width: 2, link_errors: true)
+        end
       end
 
       def month
-        date_part(:month, width: 2, link_errors: omit_day?)
+        if maxlength_enabled?
+          date_part(:month, width: 2, link_errors: omit_day?, maxlength: 2)
+        else
+          date_part(:month, width: 2, link_errors: omit_day?)
+        end
       end
 
       def year
-        date_part(:year, width: 4)
+        if maxlength_enabled?
+          date_part(:year, width: 4, maxlength: 4)
+        else
+          date_part(:year, width: 4)
+        end
       end
 
-      def date_part(segment, width:, link_errors: false)
+      def date_part(segment, width:, link_errors: false, maxlength: nil)
         tag.div(class: %(#{brand}-date-input__item)) do
           tag.div(class: %(#{brand}-form-group)) do
-            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment))])
+            safe_join([label(segment, link_errors), input(segment, link_errors, width, value(segment), maxlength)])
           end
         end
       end
@@ -96,7 +113,7 @@ module GOVUKDesignSystemFormBuilder
         )
       end
 
-      def input(segment, link_errors, width, value)
+      def input(segment, link_errors, width, value, maxlength)
         tag.input(
           id: id(segment, link_errors),
           class: classes(width),
@@ -105,7 +122,8 @@ module GOVUKDesignSystemFormBuilder
           pattern: pattern(segment),
           inputmode: 'numeric',
           value: value,
-          autocomplete: date_of_birth_autocomplete_value(segment)
+          autocomplete: date_of_birth_autocomplete_value(segment),
+          maxlength: maxlength,
         )
       end
 

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '2.7.6'.freeze
+  VERSION = '2.8.0'.freeze
 end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -162,6 +162,38 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
     end
 
+    context 'not restricting chars with maxlength' do
+      subject { builder.send(*args, maxlength_enabled: false) }
+
+      specify 'there should be a day maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{day_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a month maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{month_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a year maxlength attribute' do
+        expect(subject).not_to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{year_multiparam_attribute})]", maxlength: '4' })
+      end
+    end
+
+    context 'restricting chars with maxlength' do
+      subject { builder.send(*args, maxlength_enabled: true) }
+
+      specify 'there should be a day maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{day_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a month maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{month_multiparam_attribute})]", maxlength: '2' })
+      end
+
+      specify 'there should be a year maxlength attribute' do
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{year_multiparam_attribute})]", maxlength: '4' })
+      end
+    end
+
     context 'default values' do
       let(:birth_day) { 3 }
       let(:birth_month) { 2 }


### PR DESCRIPTION
### What

This PR adds the ability for users of the govuk_date_field and Date element to
be able to specify a maxlength attribute on each of the inputs. It defaults to
4 chars for the year, 2 chars for the month and 2 chars for the day.

- [x] Updates the form interface method :govuk_date_field to take the param
       maxlength_enabled (defaulting to false) and pass it to the Elements::Date constructor
- [x] Updates the Date element to add the maxlength value to the day, month and year inputs if enabled
- [x] Adds test coverage for each of these cases
- [x] Adds documentation and examples

### Why

We want to be able to control the number of characters the user is able
to input for the day, month and year inputs without hitting our controller
endpoint and having validations kick in.

### AC

- [x] Does not change existing behaviour
