### PR TITLE
Allow error message trust to be toggled

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -71,6 +71,10 @@ module GOVUKDesignSystemFormBuilder
   #
   # * +:enable_logger+ controls whether or not the library will emit log
   #   messages via Rails.logger.warn, defaults to +true+
+  #
+  # * +:trust_error_messages+ call html_safe on error messages before they're
+  #   rendered. This allows formatting markup to be used to change the display
+  #   of the error message. Defaults to +false+
   # ===
   DEFAULTS = {
     brand: 'govuk',
@@ -95,7 +99,8 @@ module GOVUKDesignSystemFormBuilder
     localisation_schema_legend: nil,
     localisation_schema_caption: nil,
 
-    enable_logger: true
+    enable_logger: true,
+    trust_error_messages: false,
   }.freeze
 
   DEFAULTS.each_key { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -20,7 +20,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def message
-        @builder.object.errors.messages[@attribute_name]&.first
+        error_message = @builder.object.errors.messages[@attribute_name]&.first
+
+        config.trust_error_messages ? error_message.html_safe : error_message
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -20,9 +20,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def message
-        error_message = @builder.object.errors.messages[@attribute_name]&.first
-
-        config.trust_error_messages ? error_message.html_safe : error_message
+        set_message_safety(@builder.object.errors.messages[@attribute_name]&.first)
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -81,9 +81,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def list_item(attribute, message, url = nil)
-        message = config.trust_error_messages ? message.html_safe : message
+        target = url || same_page_link(field_id(attribute))
 
-        tag.li(link_to(message, url || same_page_link(field_id(attribute)), **link_options))
+        tag.li(link_to(set_message_safety(message), target, **link_options))
       end
 
       def same_page_link(target)

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -81,6 +81,8 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def list_item(attribute, message, url = nil)
+        message = config.trust_error_messages ? message.html_safe : message
+
         tag.li(link_to(message, url || same_page_link(field_id(attribute)), **link_options))
       end
 

--- a/lib/govuk_design_system_formbuilder/traits/error.rb
+++ b/lib/govuk_design_system_formbuilder/traits/error.rb
@@ -12,6 +12,10 @@ module GOVUKDesignSystemFormBuilder
       def error_element
         @error_element ||= Elements::ErrorMessage.new(*bound)
       end
+
+      def set_message_safety(message)
+        config.trust_error_messages ? message.html_safe : message
+      end
     end
   end
 end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
@@ -1,0 +1,41 @@
+describe GOVUKDesignSystemFormBuilder::FormBuilder do
+  include_context 'setup builder'
+  include_context 'setup examples'
+
+  let(:method) { :govuk_text_field }
+  let(:attribute) { :hairstyle }
+  let(:args) { [method, attribute] }
+
+  subject { builder.send(*args) }
+
+  # the hairstyle validation message contains a linebreak `<br/>` in it
+  before { object.valid?(:trust_error_messages) }
+
+  after { GOVUKDesignSystemFormBuilder.reset! }
+
+  describe 'trust error messages config' do
+    let(:message_text) { parsed_subject.at_css('.govuk-error-message').text }
+
+    specify 'displays the error message safely by default' do
+      expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }) do
+        without_tag('br')
+      end
+
+      expect(message_text).to match(%r{<br/>})
+    end
+
+    context 'when error message content is trusted' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.trust_error_messages = true
+        end
+      end
+
+      specify 'any markup in the string becomes HTML elements' do
+        expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }) do
+          with_tag('br')
+        end
+      end
+    end
+  end
+end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
@@ -2,10 +2,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
   include_context 'setup builder'
   include_context 'setup examples'
 
-  let(:method) { :govuk_text_field }
-  let(:attribute) { :hairstyle }
-  let(:args) { [method, attribute] }
-
   subject { builder.send(*args) }
 
   # the hairstyle validation message contains a linebreak `<br/>` in it
@@ -13,7 +9,10 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
   after { GOVUKDesignSystemFormBuilder.reset! }
 
-  describe 'trust error messages config' do
+  describe 'trust error messages config for individual error messages' do
+    let(:method) { :govuk_text_field }
+    let(:attribute) { :hairstyle }
+    let(:args) { [method, attribute] }
     let(:message_text) { parsed_subject.at_css('.govuk-error-message').text }
 
     specify 'displays the error message safely by default' do
@@ -34,6 +33,35 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'any markup in the string becomes HTML elements' do
         expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }) do
           with_tag('br')
+        end
+      end
+    end
+  end
+
+  describe 'trust error messages config for an error summary' do
+    let(:method) { :govuk_error_summary }
+    let(:args) { [method] }
+
+    specify 'displays the error message safely by default' do
+      expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+        expect(subject).to have_tag('a[href="#person-hairstyle-field-error"]') do
+          without_tag('br')
+        end
+      end
+    end
+
+    context 'when error message content is trusted' do
+      before do
+        GOVUKDesignSystemFormBuilder.configure do |conf|
+          conf.trust_error_messages = true
+        end
+      end
+
+      specify 'any markup in the string becomes HTML elements' do
+        expect(subject).to have_tag('ul', with: { class: %w(govuk-list govuk-error-summary__list) }) do
+          expect(subject).to have_tag('a[href="#person-hairstyle-field-error"]') do
+            with_tag('br')
+          end
         end
       end
     end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -22,7 +22,8 @@ class Being
     :photo,
     :department,
     :stationery,
-    :stationery_choice
+    :stationery_choice,
+    :hairstyle,
   )
 
   def initialize(_args = nil)
@@ -42,6 +43,8 @@ class Person < Being
 
   validate :born_on_must_be_in_the_past, if: -> { born_on.present? }
   validate :photo_must_be_jpeg, if: -> { photo.present? }
+
+  validates :hairstyle, presence: { message: 'Describe your <br/> hairstyle' }, on: :trust_error_messages
 
   def self.valid_example
     new(


### PR DESCRIPTION
Error messages are not trusted by default - they are not marked as `html_safe`. This is because the user input might be included in the error message.

Including the user's input in the message (e.g., "31 02 2019 is not a valid date") is not a common practice in GOV.UK projects and sometimes teams might want to add extra formatting, like a line break, to an error message to make it easier to read.

To support this, this change introduces a toggle in the config. When true, it will call `#html_safe` on all error messages before they're injected into the output - this will maintain any HTML tags.

The default value is false - no behaviour will change unless the setting is manually enabled.

## Remaining tasks

* [x] Work out whether this a good idea
* [x] Add support for the error messages in the error summary

Fixes #328
