### PR TITLE
GOV.UK Design System 4.0.0

### DIFF
--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -91,7 +91,7 @@ module Helpers
     end
 
     def rails_checkbox_gotcha_link
-      'https://api.rubyonrails.org/v6.1/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha'
+      'https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-check_box-label-Gotcha'
     end
 
     def rails_option_for_select_link

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -5,16 +5,17 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "guide",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^3.14.0"
+        "govuk-frontend": "^4.0.0"
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -22,9 +23,9 @@
   },
   "dependencies": {
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     }
   }
 }

--- a/guide/package.json
+++ b/guide/package.json
@@ -12,6 +12,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^3.14.0"
+    "govuk-frontend": "^4.0.0"
   }
 }

--- a/lib/govuk_design_system_formbuilder/elements/error_message.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_message.rb
@@ -8,7 +8,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return unless has_errors?
 
-        tag.span(class: %(#{brand}-error-message), id: error_id) do
+        tag.p(class: %(#{brand}-error-message), id: error_id) do
           safe_join([hidden_prefix, message])
         end
       end

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -27,7 +27,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return unless active?
 
-        content_tag(hint_tag, **hint_options, **@html_attributes) { hint_body }
+        tag.div(**hint_options, **@html_attributes) { hint_body }
       end
 
       def hint_id
@@ -40,10 +40,6 @@ module GOVUKDesignSystemFormBuilder
 
       def hint_options
         { class: classes, id: hint_id }
-      end
-
-      def hint_tag
-        @raw.presence ? 'div' : 'span'
       end
 
       def hint_body

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/check_box_spec.rb
@@ -84,11 +84,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'should contain a hint with the correct text' do
-        expect(subject).to have_tag('span', text: hint_text)
+        expect(subject).to have_tag('div', text: hint_text)
       end
 
       specify 'the hint should have the correct classes' do
-        expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-checkboxes__hint) })
+        expect(subject).to have_tag('div', with: { class: %w(govuk-hint govuk-checkboxes__hint) })
       end
 
       context 'when the hint is supplied in a proc' do

--- a/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/check_boxes/collection_spec.rb
@@ -115,7 +115,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
           specify 'hints should contain the correct content' do
             projects.map(&:description).compact.each do |hint_text|
-              expect(subject).to have_tag('span', text: hint_text, with: { class: %w(govuk-hint govuk-checkboxes__hint) })
+              expect(subject).to have_tag('div', text: hint_text, with: { class: %w(govuk-hint govuk-checkboxes__hint) })
             end
           end
 
@@ -131,17 +131,17 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
 
           specify 'only items with descriptions should have hints' do
-            expect(subject).to have_tag('span', with: { class: 'govuk-hint' }, count: projects_with_descriptions.size)
+            expect(subject).to have_tag('div', with: { class: 'govuk-hint' }, count: projects_with_descriptions.size)
           end
 
           specify 'hints should have the correct classes' do
-            expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-checkboxes__hint) })
+            expect(subject).to have_tag('div', with: { class: %w(govuk-hint govuk-checkboxes__hint) })
           end
         end
 
         context 'when no hint method is provided' do
           specify 'the hint tag should never be present' do
-            expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+            expect(subject).not_to have_tag('div', with: { class: 'govuk-hint' })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/localisation_configuration_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/localisation_configuration_spec.rb
@@ -59,7 +59,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
 
         specify 'should use the configured localisation schema for hints' do
           with_localisations(localisations) do
-            expect(subject).to have_tag('span', text: hint_text, with: { class: 'govuk-hint' })
+            expect(subject).to have_tag('div', text: hint_text, with: { class: 'govuk-hint' })
           end
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/configuration/trust_error_messages_spec.rb
@@ -16,7 +16,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     let(:message_text) { parsed_subject.at_css('.govuk-error-message').text }
 
     specify 'displays the error message safely by default' do
-      expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }) do
+      expect(subject).to have_tag('p', with: { class: 'govuk-error-message' }) do
         without_tag('br')
       end
 
@@ -31,7 +31,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'any markup in the string becomes HTML elements' do
-        expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }) do
+        expect(subject).to have_tag('p', with: { class: 'govuk-error-message' }) do
           with_tag('br')
         end
       end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -39,9 +39,9 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     it_behaves_like 'a field that accepts arbitrary blocks of HTML' do
       let(:described_element) { 'fieldset' }
 
-      # the block content (p) should be between the hint (span) and the input container (div)
+      # the block content should be before the hint and date inputs
       context 'ordering' do
-        let(:hint_span_selector) { 'span.govuk-hint' }
+        let(:hint_div_selector) { 'div.govuk-hint' }
         let(:block_paragraph_selector) { 'p.block-content' }
         let(:govuk_date_selector) { 'div.govuk-date-input' }
 
@@ -53,10 +53,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           end
         end
 
-        specify 'the block content should be between the hint and the date inputs' do
-          expect(
-            parsed_subject.css([hint_span_selector, block_paragraph_selector, govuk_date_selector].join(',')).map(&:name)
-          ).to eql(%w(p span div))
+        specify 'the block content should be before the hint and the date inputs' do
+          actual = parsed_subject.css([hint_div_selector, block_paragraph_selector, govuk_date_selector].join(",")).flat_map(&:classes)
+          expected = %w(block-content govuk-hint govuk-date-input)
+
+          expect(actual).to eql(expected)
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/collection_spec.rb
@@ -136,14 +136,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         subject { builder.send(*args.push(:description)) }
 
         specify 'the radio buttons with hints should contain hint text' do
-          expect(subject).to have_tag('span', count: colours_with_descriptions.size, with: { class: 'govuk-hint govuk-radios__hint' })
+          expect(subject).to have_tag('div', count: colours_with_descriptions.size, with: { class: 'govuk-hint govuk-radios__hint' })
         end
 
         specify 'the hint should be associated with the correct radio button' do
           colours_with_descriptions.each do |cwd|
             "person-favourite-colour-#{cwd.id}-hint".tap do |association|
               expect(subject).to have_tag('input', with: { "aria-describedby" => association })
-              expect(subject).to have_tag('span', with: { class: 'govuk-hint', id: association })
+              expect(subject).to have_tag('div', with: { class: 'govuk-hint', id: association })
             end
           end
         end

--- a/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/fieldset_spec.rb
@@ -170,7 +170,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         %i[red green].each do |value|
           hint_id = "person-favourite-colour-#{value}-hint"
           expect(subject).to have_tag('input', with: { "aria-describedby" => hint_id })
-          expect(subject).to have_tag('span', with: { class: 'govuk-hint', id: hint_id })
+          expect(subject).to have_tag('div', with: { class: 'govuk-hint', id: hint_id })
         end
       end
     end

--- a/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/radios/radio_button_spec.rb
@@ -81,11 +81,11 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       specify 'should contain a hint with the correct text' do
-        expect(subject).to have_tag('span', text: red_hint)
+        expect(subject).to have_tag('div', text: red_hint)
       end
 
       specify 'the hint should have the correct classes' do
-        expect(subject).to have_tag('span', with: { class: %w(govuk-hint govuk-radios__hint) })
+        expect(subject).to have_tag('div', with: { class: %w(govuk-hint govuk-radios__hint) })
       end
 
       context 'when the hint is supplied in a proc' do

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -3,7 +3,7 @@ shared_examples 'a field that supports errors' do
     before { object.valid? }
 
     specify 'an error message should be displayed' do
-      expect(subject).to have_tag('span', with: { class: 'govuk-error-message' }, text: error_message)
+      expect(subject).to have_tag('p', with: { class: 'govuk-error-message' }, text: error_message)
     end
 
     specify 'the form group should have the correct error classes' do
@@ -18,7 +18,7 @@ shared_examples 'a field that supports errors' do
 
     specify 'the error message should be associated with the correct element' do
       expect(subject).to have_tag(aria_described_by_target, with: { 'aria-describedby' => error_identifier })
-      expect(subject).to have_tag('span', with: {
+      expect(subject).to have_tag('p', with: {
         class: 'govuk-error-message',
         id: error_identifier
       })
@@ -41,18 +41,18 @@ shared_examples 'a field that supports errors' do
       end
 
       specify 'the first error should be included' do
-        expect(subject).to have_tag('span', text: Regexp.new(first_error))
+        expect(subject).to have_tag('p', text: Regexp.new(first_error))
       end
 
       specify 'the second error should not be included' do
-        expect(subject).not_to have_tag('span', text: Regexp.new(second_error))
+        expect(subject).not_to have_tag('p', text: Regexp.new(second_error))
       end
     end
   end
 
   context 'when the attribute has no errors' do
     specify 'no error messages should be displayed' do
-      expect(subject).not_to have_tag('span', with: { class: 'govuk-error-message' })
+      expect(subject).not_to have_tag('p', with: { class: 'govuk-error-message' })
     end
   end
 

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -2,9 +2,9 @@ shared_examples 'a field that supports hints' do
   context 'when a hint is provided as a string' do
     subject { builder.send(*args, hint: { text: hint_text }) }
 
-    specify 'output should contain a hint in a span tag' do
+    specify 'output should contain a hint' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
-        with_tag('span', text: hint_text, with: { class: 'govuk-hint' })
+        with_tag('div', text: hint_text, with: { class: 'govuk-hint' })
       end
     end
 
@@ -16,7 +16,7 @@ shared_examples 'a field that supports hints' do
 
     specify 'the hint should be associated with the input' do
       input_aria_describedby = parsed_subject.at_css(aria_described_by_target)['aria-describedby'].split
-      hint_id = parsed_subject.at_css('span.govuk-hint')['id']
+      hint_id = parsed_subject.at_css('div.govuk-hint')['id']
       expect(input_aria_describedby).to include(hint_id)
     end
 
@@ -42,7 +42,7 @@ shared_examples 'a field that supports hints' do
 
     subject { builder.send(*args, hint: hint) }
 
-    specify 'output should contain a hint in a div tag' do
+    specify 'output should contain a hint' do
       expect(subject).to have_tag('div', with: { class: 'govuk-form-group' }) do
         with_tag('div', with: { class: 'govuk-hint' })
       end
@@ -70,7 +70,7 @@ shared_examples 'a field that supports hints' do
     subject { builder.send(*args, hint: nil) }
 
     specify 'no hint should be present' do
-      expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+      expect(subject).not_to have_tag('div', with: { class: 'govuk-hint' })
     end
 
     specify 'output should have no empty aria-describedby attribute' do
@@ -82,7 +82,7 @@ shared_examples 'a field that supports hints' do
     subject { builder.send(*args) }
 
     specify 'no hint should be present' do
-      expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+      expect(subject).not_to have_tag('div', with: { class: 'govuk-hint' })
     end
 
     specify 'output should have no empty aria-describedby attribute' do

--- a/spec/support/shared/shared_localisation_examples.rb
+++ b/spec/support/shared/shared_localisation_examples.rb
@@ -157,7 +157,7 @@ shared_examples 'a field that supports setting the hint via localisation' do
 
     specify 'should set the hint from the locales' do
       with_localisations(localisations) do
-        expect(subject).to have_tag('span', text: expected_hint, with: { class: 'govuk-hint' })
+        expect(subject).to have_tag('div', text: expected_hint, with: { class: 'govuk-hint' })
       end
     end
   end
@@ -171,7 +171,7 @@ shared_examples 'a field that supports setting the hint via localisation' do
 
     specify 'should use the supplied hint text' do
       with_localisations(localisations) do
-        expect(subject).to have_tag('span', text: expected_hint, with: { class: 'govuk-hint' })
+        expect(subject).to have_tag('div', text: expected_hint, with: { class: 'govuk-hint' })
       end
     end
   end
@@ -183,7 +183,7 @@ shared_examples 'a field that supports setting the hint via localisation' do
 
     specify 'no hint should be rendered' do
       with_localisations(localisations) do
-        expect(subject).not_to have_tag('span', with: { class: 'govuk-hint' })
+        expect(subject).not_to have_tag('div', with: { class: 'govuk-hint' })
       end
     end
   end
@@ -266,7 +266,7 @@ shared_examples 'a field that allows the hint to be localised via a proc' do
       with_localisations({ locale => localisations }, locale: locale) do
         colours.each do |c|
           expect(subject).to have_tag(
-            'span',
+            'div',
             text: localisations.dig("colours", c.name.downcase),
             with: { class: 'govuk-hint' }
           )
@@ -302,7 +302,7 @@ shared_examples 'a field that supports localised collection hints' do
         expected_hint = I18n.translate(department.code, scope: 'helpers.hint.person.department_options', default: nil)
 
         if expected_hint.present?
-          expect(subject).to have_tag('span', with: { class: %w(govuk-hint).append(hint_class) }, text: expected_hint)
+          expect(subject).to have_tag('div', with: { class: %w(govuk-hint).append(hint_class) }, text: expected_hint)
         end
       end
 
@@ -313,7 +313,7 @@ shared_examples 'a field that supports localised collection hints' do
         I18n.translate(department.code, scope: 'helpers.hint.person.department_options', default: nil)
       end
 
-      expect(subject).to have_tag('span', with: { class: %w(govuk-hint).append(hint_class) }, count: departments_with_localised_hints)
+      expect(subject).to have_tag('div', with: { class: %w(govuk-hint).append(hint_class) }, count: departments_with_localised_hints)
     end
   end
 end
@@ -326,7 +326,7 @@ shared_examples 'a field that supports localised fieldset hints' do
     with_localisations(localisations) do
       expected_hints.each do |id, hint|
         expected_id = ["person", field_name_selector, id, "hint"].join("-")
-        expect(subject).to have_tag("span", with: { id: expected_id }, text: hint)
+        expect(subject).to have_tag("div", with: { id: expected_id }, text: hint)
       end
     end
   end


### PR DESCRIPTION
The next major version of this library will add support for the GOV.UK Design System 4.0.0 which introduces some minor breaking changes:

- [x] Update error messages so they're rendered in `<p>` elements instead of `<span>` 02c43fc
- [x] Always render hints in `<div>` elements, drop the conditional behaviour where we render strings in `<span>` and procs in `<div>` elements 8189646
