### PR TITLE
Update supported versions and docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6.8', '2.7.4', '3.0.2']
-        rails: ['6.0.4.1', '6.1.4.1']
+        ruby: ['2.7.5', '3.0.3']
+        rails: ['6.1.4.4', '7.0.0']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
@@ -43,11 +43,11 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0.1'
+          ruby-version: '3.0.3'
 
       - name: Install gems
         env:
-          RAILS_VERSION: '6.1.3.2'
+          RAILS_VERSION: '7.0.0'
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-formbuilder/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk-formbuilder/blob/master/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-3.14.0-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Rails-6.0.4.1%20%E2%95%B1%206.1.4.1-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-2.6.8%20%E2%95%B1%202.7.4%20%E2%95%B1%203.0.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Rails-6.1.4.4%20%E2%95%B1%207.0.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Ruby-2.7.5%20%20%E2%95%B1%203.0.3-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -8,7 +8,18 @@ p.govuk-body
   | The form builder is actively maintained and will continue support the
     latest stable versions of the GOV.UK Design System, Ruby and Rails.
 
+h2.govuk-heading-m Full support
+
 dl.govuk-summary-list
+  .govuk-summary-list__row
+    dt.govuk-summary-list__key
+      == link_to('GOV.UK Form Builder', '/')
+    dl.govuk-summary-list__value
+      ul.govuk-list
+        li
+          span.govuk-tag.govuk-tag-blue
+            = GOVUKDesignSystemFormBuilder::VERSION
+
   .govuk-summary-list__row
     dt.govuk-summary-list__key
       == link_to('GOV.UK Design System', design_system_link)
@@ -16,7 +27,7 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-govuk
-            | Version 3.14.0
+            | Version 4.0.0
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key
@@ -25,13 +36,10 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
-            | 3.0.2
+            | 3.0.3
         li
           span.govuk-tag.govuk-tag-red
-            | 2.7.4
-        li
-          span.govuk-tag.govuk-tag-red
-            | 2.6.8
+            | 2.7.5
 
   .govuk-summary-list__row
     dt.govuk-summary-list__key
@@ -40,7 +48,22 @@ dl.govuk-summary-list
       ul.govuk-list
         li
           span.govuk-tag.govuk-tag-red
-            | 6.1.4.1
+            | 7.0.0
         li
           span.govuk-tag.govuk-tag-red
-            | 6.0.4.1
+            | 6.1.4.4
+
+h2.govuk-heading-m Partial support
+
+p.govuk-body
+  | If you're using older versions of the GOV.UK Design System, Ruby or Rails, use
+    #{link_to("version 2.8.0", github_release_2_8_0).html_safe}. It supports:
+
+ul.govuk-list.govuk-list--bullet
+  li GOV.UK Design System 3.14.0
+  li Rails 6.0.4.4
+  li Ruby 2.6.9
+
+p.govuk-body
+  | No new features will be added to version 2.8.X series but <strong>bugs and
+    security fixes will be addressed</strong>.

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -30,6 +30,10 @@ module Helpers
       'https://github.com/DFE-Digital/govuk-formbuilder'
     end
 
+    def github_release_2_8_0
+      'https://github.com/DFE-Digital/govuk-formbuilder/releases/tag/v2.8.0'
+    end
+
     def design_system_link
       'https://design-system.service.gov.uk'
     end


### PR DESCRIPTION
Version 3.0.0 will add support for Rails 7.0.0 which no longer supports Ruby 2.6.0, so it will be dropped.

As some people might not be able to upgrade immediately, the 2.8.0 series will be considered partially supported - bugs and security issues will continue be fixed but no new functionality added.