### PR TITLE
Remove fallbacks for old versions of Ruby and Rails

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/html_classes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_classes.rb
@@ -6,30 +6,7 @@ module GOVUKDesignSystemFormBuilder
       # Rails' class_names, but recreated here as that returns a string
       # where we want an array.
       def build_classes(*args, **kwargs)
-        # FIXME: we need to handle the arguments differently for Ruby 2.6.x because
-        #        Ruby 2.7.0 brought the separation of positional and keyword
-        #        arguments.
-        #
-        #        This can be removed once support for 2.6.x is dropped.
-        #
-        #        https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
-        return ruby_2_6_build_classes_fallback(*args) if RUBY_VERSION < "2.7.0"
-
         (args + kwargs.map { |k, v| k if v }).compact
-      end
-
-    private
-
-      def ruby_2_6_build_classes_fallback(*args)
-        [].tap do |classes|
-          args.each do |arg|
-            if arg.is_a?(Hash)
-              arg.each { |k, v| classes.append(k) if v }
-            else
-              classes.append(arg)
-            end
-          end
-        end
       end
     end
   end

--- a/spec/support/examples.rb
+++ b/spec/support/examples.rb
@@ -57,15 +57,7 @@ class Person < Being
   end
 
   def self.with_errors_on_base(msg = "This person is always invalid")
-    new.tap do |person|
-      if rails_version_later_than_6_1_0?
-        person.errors.add(:base, msg)
-      else
-        # :nocov:
-        person.errors[:base].push(msg)
-        # :nocov:
-      end
-    end
+    new.tap { |person| person.errors.add(:base, msg) }
   end
 
 private

--- a/spec/support/shared/shared_error_examples.rb
+++ b/spec/support/shared/shared_error_examples.rb
@@ -30,14 +30,8 @@ shared_examples 'a field that supports errors' do
       let(:error_messages) { [first_error, second_error] }
 
       before do
-        if rails_version_later_than_6_1_0?
-          object.errors.clear
-          error_messages.each { |m| object.errors.add(attribute, m) }
-        else
-          # :nocov:
-          allow(object.errors.messages).to(receive(:[]).and_return(error_messages))
-          # :nocov:
-        end
+        object.errors.clear
+        error_messages.each { |m| object.errors.add(attribute, m) }
       end
 
       specify 'the first error should be included' do

--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -22,10 +22,6 @@ def rails_version
   ENV.fetch('RAILS_VERSION') { '6.1.1' }
 end
 
-def rails_version_later_than_6_1_0?
-  rails_version >= '6.1.0'
-end
-
 def extract_field_names_from_errors_summary_list(document)
   document
     .css('li > a')


### PR DESCRIPTION
- Remove legacy class-building method for Ruby 2.6.0
- Remove fallbacks for Rails 6.0.X
