### PR TITLE
Change default turbolinks prefix to turbo

### DIFF
--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -57,8 +57,8 @@ module GOVUKDesignSystemFormBuilder
   # * +:default_error_summary_turbo_prefix+ is used to disable turbo/turbolinks from
   #   handling clicks on links in the error summary. When it's a string (eg,
   #   turbo), that will result in links with the attribute 'data-turbo=false'.
-  #   When nil, no data attribute will be added. Defaults to 'turbolinks' for
-  #   compatibilitiy's sake; this will change to 'turbo' when Rails 7 is released
+  #   When nil, no data attribute will be added. Defaults to turbo since Rails 7,
+  #   change to 'turbolinks' for Rails 6.1
   #
   # * +:localisation_schema_fallback+ sets the prefix elements for the array
   #   used to build the localisation string. The final two elements are always
@@ -88,7 +88,7 @@ module GOVUKDesignSystemFormBuilder
     default_error_summary_title: 'There is a problem',
     default_error_summary_presenter: Presenters::ErrorSummaryPresenter,
     default_error_summary_error_order_method: nil,
-    default_error_summary_turbo_prefix: 'turbolinks',
+    default_error_summary_turbo_prefix: 'turbo',
     default_collection_check_boxes_include_hidden: true,
     default_collection_radio_buttons_include_hidden: true,
     default_submit_validate: false,

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -73,7 +73,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           object.errors.messages.each do |attribute, _msg|
             expect(subject).to have_tag('a', with: {
               href: "#person-#{underscores_to_dashes(attribute)}-field-error",
-              'data-turbolinks' => false
+              'data-turbo' => false
             })
           end
         end


### PR DESCRIPTION
This should really have been done with v3.0.0 but was overlooked. As we're targetting Rails 7 by default it should work out of the box.

If you've not made the jump to Rails 7, set `config.default_error_summary_turbo_prefix = 'turbolinks'` in [your form builder config initializer](https://www.rubydoc.info/gems/govuk_design_system_formbuilder/GOVUKDesignSystemFormBuilder).
