### PR TITLE
Bump Ruby version to stop guide build failing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0.3'
+          ruby-version: '3.1.0'
 
       - name: Install gems
         env:


### PR DESCRIPTION
The recent update to Psych changed the argument format from positional to keyword arguments. Nanoc uses this format so we should follow.
