### PR TITLE
Remove tabindex from Error Summary

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -121,7 +121,6 @@ module GOVUKDesignSystemFormBuilder
       def options
         {
           class: classes,
-          tabindex: -1,
           role: 'alert',
           data: {
             module: %(#{brand}-error-summary)

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -29,7 +29,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
           'div',
           with: {
             class: 'govuk-error-summary',
-            tabindex: '-1',
             role: 'alert',
             'data-module' => 'govuk-error-summary'
           }


### PR DESCRIPTION
The `tabindex` attribute on the Error Summary no longer needs to be set within the HTML, as this is set via javascript, as of govuk-frontend 4.0.1.

See [govuk-frontend 4.0.1 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.1).