### PR TITLE
Add a sitemap to the guide

### DIFF
--- a/guide/Rules
+++ b/guide/Rules
@@ -18,6 +18,11 @@ compile '/**/*.scss' do
   write item.identifier.without_ext + '.css'
 end
 
+compile '/sitemap.erb.xml' do
+  filter :erb
+  write '/sitemap.xml'
+end
+
 compile '/**/*' do
   write item.identifier.to_s
 end

--- a/guide/content/index.slim
+++ b/guide/content/index.slim
@@ -1,2 +1,6 @@
+---
+priority: 1
+---
+
 == render '/partials/masthead.*'
 == render '/partials/links.*'

--- a/guide/content/sitemap.erb.xml
+++ b/guide/content/sitemap.erb.xml
@@ -1,0 +1,1 @@
+<%= xml_sitemap(items: items.select { |item| item.identifier.ext == "slim" }) %>

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -12,6 +12,7 @@ require 'govuk_design_system_formbuilder'
 
 use_helper Nanoc::Helpers::Rendering
 use_helper Nanoc::Helpers::LinkTo
+use_helper Nanoc::Helpers::XMLSitemap
 
 use_helper Helpers::Formatters
 use_helper Helpers::LinkHelpers

--- a/guide/nanoc.yaml
+++ b/guide/nanoc.yaml
@@ -16,3 +16,5 @@ checks:
       # ruby doc sometimes fails because the docs are built when the request is
       # made which nano reports as failure (202)
       - '^https?://www.rubydoc.info/'
+
+base_url: https://govuk-form-builder.netlify.app


### PR DESCRIPTION
The Nanoc helper makes this really easy, we're using Nanoc's list of items so partials aren't included and we just need to filter to slim files in `xml_sitemap`.

This doesn't set `changefreq` - not sure how important they are. If we add them they needed to be added to each page's frontmatter individually, probably set to `yearly`
