### PR TITLE
Use `html_attributes_utils` gem over `deep_merge`

### DIFF
--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.metadata    = METADATA
   s.files       = Dir["{app,lib}/**/*", "LICENSE", "README.md"]
 
-  s.add_dependency("deep_merge", "~> 1.2.1")
+  s.add_dependency("html-attributes-utils", "~> 0.9.0")
 
   exact_rails_version = ENV.key?("RAILS_VERSION")
   rails_version = ENV.fetch("RAILS_VERSION") { "6.1.5" }

--- a/lib/govuk_design_system_formbuilder.rb
+++ b/lib/govuk_design_system_formbuilder.rb
@@ -1,5 +1,5 @@
-require 'deep_merge/rails_compat'
 require 'active_support/configurable'
+require 'html_attributes_utils'
 
 [%w(presenters *.rb), %w(refinements *.rb), %w(traits *.rb), %w(*.rb), %w(elements ** *.rb), %w(containers ** *.rb)]
   .flat_map { |matcher| Dir.glob(File.join(__dir__, 'govuk_design_system_formbuilder', *matcher)) }

--- a/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
+++ b/lib/govuk_design_system_formbuilder/traits/html_attributes.rb
@@ -1,68 +1,12 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module HTMLAttributes
-      # Attributes eases working with default and custom attributes by:
-      # * deeply merging them so both the default (required) attributes are
-      #   present
-      # * joins the arrays into strings to maintain Rails 6.0.* compatibility
-      class Attributes
-        # Only try to combine and merge these attributes that contain a list of
-        # values separated by a space. All other values should be merged in a
-        # regular fashion (where the custom value overrides the default)
-        MERGEABLE = [
-          %i(class),
-          %i(aria controls),
-          %i(aria describedby),
-          %i(aria flowto),
-          %i(aria labelledby),
-          %i(aria owns),
-        ].freeze
-
-        def initialize(defaults, custom)
-          @merged = defaults.deeper_merge(deep_split_values(custom))
-        end
-
-        def to_h
-          deep_join_values(@merged)
-        end
-
-      private
-
-        def deep_split_values(hash, parent = nil)
-          hash.each.with_object({}) do |(key, value), result|
-            result[key] = case value
-                          when Hash
-                            deep_split_values(value, key)
-                          when String
-                            split_mergeable(key, value, parent)
-                          else
-                            value
-                          end
-          end
-        end
-
-        def split_mergeable(key, value, parent = nil)
-          return value.presence unless [parent, key].compact.in?(MERGEABLE)
-
-          value.split
-        end
-
-        def deep_join_values(hash)
-          hash.each.with_object({}) do |(key, value), result|
-            result[key] = case value
-                          when Hash
-                            deep_join_values(value)
-                          when Array
-                            value.uniq.join(' ').presence
-                          else
-                            value
-                          end
-          end
-        end
-      end
+      using HTMLAttributesUtils
 
       def attributes(html_attributes = {})
-        Attributes.new(options, html_attributes).to_h
+        options
+          .deep_merge_html_attributes(html_attributes)
+          .deep_tidy_html_attributes
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/version.rb
+++ b/lib/govuk_design_system_formbuilder/version.rb
@@ -1,3 +1,3 @@
 module GOVUKDesignSystemFormBuilder
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.0.3b1'.freeze
 end


### PR DESCRIPTION
The `deep_merge` gem is incredibly powerful and versatile but isn't the best fit for the specific task of merging HTML attributes while paying attention to some special rules, like the splitting and merging of certain attributes. This is useful in things like `class:`, where a list of values is represented by a space-delimited string.

The new gem, `html-attributes-utils`, was created using the code removed in this commit as a basis. It will benefit from being easier to test standalone and can be reused in the govuk-components library too - and maybe beyond!

Fixes #356 