### PR TITLE
Remove #rails_version spec utility method

### DIFF
--- a/spec/support/utility.rb
+++ b/spec/support/utility.rb
@@ -18,10 +18,6 @@ def dashes_to_underscores(val)
   val.to_s.tr('-', '_')
 end
 
-def rails_version
-  ENV.fetch('RAILS_VERSION') { '6.1.1' }
-end
-
 def extract_field_names_from_errors_summary_list(document)
   document
     .css('li > a')


### PR DESCRIPTION
It's not been used since Rails 6 support was dropped and had a negative effect on coverage.
