### PR TITLE
Remove wildcard and pattern from date object

### DIFF
--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -913,7 +913,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param maxlength_enabled [Boolean] adds maxlength attribute to day, month and year inputs (2, 2, and 4, respectively)
-    # @param wildcards [Boolean] add an 'X' to the day and month patterns so users can add approximate dates
     # @param form_group [Hash] configures the form group
     # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
@@ -937,8 +936,8 @@ module GOVUKDesignSystemFormBuilder
     # @example A date input with legend supplied as a proc
     #  = f.govuk_date_field :finishes_on,
     #    legend: -> { tag.h3('Which category do you belong to?') }
-    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, form_group: {}, wildcards: false, **kwargs, &block)
-      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, maxlength_enabled: maxlength_enabled, form_group: form_group, wildcards: wildcards, **kwargs, &block).html
+    def govuk_date_field(attribute_name, hint: {}, legend: {}, caption: {}, date_of_birth: false, omit_day: false, maxlength_enabled: false, form_group: {}, **kwargs, &block)
+      Elements::Date.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, date_of_birth: date_of_birth, omit_day: omit_day, maxlength_enabled: maxlength_enabled, form_group: form_group, **kwargs, &block).html
     end
 
     # Generates a summary of errors in the form, each linking to the corresponding

--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -11,7 +11,7 @@ module GOVUKDesignSystemFormBuilder
       SEGMENTS = { day: '3i', month: '2i', year: '1i' }.freeze
       MULTIPARAMETER_KEY = { day: 3, month: 2, year: 1 }.freeze
 
-      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, form_group:, wildcards:, date_of_birth: false, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, legend:, caption:, hint:, omit_day:, maxlength_enabled:, form_group:, date_of_birth: false, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
         @legend            = legend
@@ -21,7 +21,6 @@ module GOVUKDesignSystemFormBuilder
         @omit_day          = omit_day
         @maxlength_enabled = maxlength_enabled
         @form_group        = form_group
-        @wildcards         = wildcards
         @html_attributes   = kwargs
       end
 
@@ -107,18 +106,11 @@ module GOVUKDesignSystemFormBuilder
           class: classes(width),
           name: name(segment),
           type: 'text',
-          pattern: pattern(segment),
           inputmode: 'numeric',
           value: value,
           autocomplete: date_of_birth_autocomplete_value(segment),
           maxlength: (width if maxlength_enabled?),
         )
-      end
-
-      def pattern(segment)
-        return '[0-9X]*' if @wildcards && segment.in?(%i(day month))
-
-        '[0-9]*'
       end
 
       def classes(width)

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -102,14 +102,8 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         end
       end
 
-      context 'input attributes' do
-        specify 'inputs should have a pattern that restricts entries to numbers' do
-          expect(subject).to have_tag('input', with: { pattern: '[0-9]*' })
-        end
-
-        specify 'inputs should have an inputmode of numeric' do
-          expect(subject).to have_tag('input', with: { inputmode: 'numeric' })
-        end
+      specify 'inputs should have an inputmode of numeric' do
+        expect(subject).to have_tag('input', with: { inputmode: 'numeric' })
       end
 
       specify 'labels should be associated with inputs' do
@@ -275,19 +269,6 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
         specify "year field should have autocomplete attribute with value 'bday-year'" do
           expect(subject).to have_tag('input', with: { autocomplete: 'bday-year' })
         end
-      end
-    end
-
-    describe "wildcards" do
-      subject { builder.send(*args, wildcards: true) }
-
-      specify %(the date and month input patterns contain an X) do
-        expect(subject).to have_tag('input', with: { id: day_identifier, pattern: "[0-9X]*" })
-        expect(subject).to have_tag('input', with: { id: month_identifier, pattern: "[0-9X]*" })
-      end
-
-      specify %(the year pattern doesn't contain an X) do
-        expect(subject).to have_tag('input', with: { id: year_identifier, pattern: "[0-9]*" })
       end
     end
 


### PR DESCRIPTION
Wildcards are [no longer recommended](https://github.com/alphagov/govuk-frontend/pull/2599) by the design system as of [v4.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0)

Fixes #361 