### PR TITLE
Drop the aria-live attribute from text area

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/text_area.rb
+++ b/lib/govuk_design_system_formbuilder/elements/text_area.rb
@@ -78,7 +78,7 @@ module GOVUKDesignSystemFormBuilder
       def limit_description
         return unless limit?
 
-        tag.span(id: limit_id, class: limit_description_classes, aria: { live: 'polite' }) do
+        tag.span(id: limit_id, class: limit_description_classes) do
           "You can enter up to #{limit_quantity} #{limit_type}"
         end
       end


### PR DESCRIPTION
The `aria-live="polite"` attribute on text areas with a word/character count is [no longer recommended](https://github.com/alphagov/govuk-frontend/pull/2577/) by the design system as of [v4.1.0](https://github.com/alphagov/govuk-frontend/releases/tag/v4.1.0).
