### PR TITLE
Ensure date field without a day works correctly

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/date.rb
+++ b/lib/govuk_design_system_formbuilder/elements/date.rb
@@ -53,7 +53,14 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def day
-        return if omit_day?
+        if omit_day?
+          return tag.input(
+            id: id(:day, false),
+            name: name(:day),
+            type: 'hidden',
+            value: value(:day) || 1,
+          )
+        end
 
         date_part(:day, width: 2, link_errors: true)
       end

--- a/spec/govuk_design_system_formbuilder/builder/date_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/date_spec.rb
@@ -139,12 +139,14 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
     context 'showing only month and year inputs' do
       subject { builder.send(*args, omit_day: true) }
 
-      specify 'there should only be month and year inputs' do
-        expect(subject).to have_tag('input', count: 2)
+      specify 'there should only be month and year text inputs' do
+        expect(subject).to have_tag('input', count: 3)
 
         [month_multiparam_attribute, year_multiparam_attribute].each do |mpa|
-          expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{mpa})]" })
+          expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{mpa})]", type: 'text' })
         end
+
+        expect(subject).to have_tag('input', with: { name: "#{object_name}[#{attribute}(#{day_multiparam_attribute})]", type: 'hidden' })
       end
 
       specify 'there be no day label' do

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -281,11 +281,12 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
                   expect(subject).to have_tag('input', with: { id: identifier }, count: 1)
                 end
 
-                specify 'the targetted input should be the first field' do
-                  expect(parsed_subject.css("input").first).to eql(parsed_subject.at_css('#' + identifier))
+                specify 'the targeted input should be the first non-hidden field' do
+                  inputs = parsed_subject.css('input').reject { |el| el.attributes['type'].value == 'hidden' }
+                  expect(inputs.first).to eql(parsed_subject.at_css('#' + identifier))
                 end
 
-                specify 'the targetted input should be the day field' do
+                specify 'the targeted input should be the day field' do
                   expect(parsed_subject.at_css('#' + identifier).attribute('name').value).to eql(first_date_segment_name)
                 end
               end


### PR DESCRIPTION
In https://github.com/DFE-Digital/govuk-formbuilder/pull/57 the date field was modified to support showing an approximate date (without a day field). However, it seems like it's not quite working as expected as Rails ignores the field as there's no HTML `input` element for the day part of the date.

This is demonstrated by https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/250/commits/03e6281e25081610aa70a9b22b541dac256b6c4a which required me to manually add hidden input fields for the two approximate date fields representing the day component, and setting the value to "1".

The built-in Rails equivalent date select helper also renders a hidden field for the day component, so it makes sense that we match this behaviour: https://github.com/rails/rails/blob/b5a758db1ba16233f53c76dea588c0e3853c7c42/actionview/lib/action_view/helpers/date_helper.rb#L814-L820