### PR TITLE
Stop code background colour obscuring text

### DIFF
--- a/guide/content/stylesheets/components/_highlight.scss
+++ b/guide/content/stylesheets/components/_highlight.scss
@@ -15,38 +15,42 @@ $bright-purple: govuk-colour('bright-purple');
 
 $text: $govuk-text-colour;
 
-pre > code {
-  &.highlight {
-    color: $text;
+.app-prose {
+  pre > code {
+    background-color: transparent;
 
-    .s,.s1,.s2,.vi,.sx {
-      color: $pink;
-    }
+    &.highlight {
+      color: $text;
 
-    .nt,.nf,.nc {
-      color: $orange;
+      .s,.s1,.s2,.vi,.sx {
+        color: $pink;
       }
 
-    .n,.p,.k,.mi,.n,.o,.na,.ss {
-      color: $dark-blue;
-    }
+      .nt,.nf,.nc {
+        color: $orange;
+        }
 
-    .k {
-      font-weight: 600;
-    }
+      .n,.p,.k,.mi,.n,.o,.na,.ss {
+        color: $dark-blue;
+      }
 
-    .no {
-      color: $green;
-    }
+      .k {
+        font-weight: 600;
+      }
 
-    .kp {
-      color: $green;
-    }
+      .no {
+        color: $green;
+      }
 
-    // comments
-    .c1 {
-      color: $turquoise;
-      font-style: italic;
+      .kp {
+        color: $green;
+      }
+
+      // comments
+      .c1 {
+        color: $turquoise;
+        font-style: italic;
+      }
     }
   }
 }


### PR DESCRIPTION
Make `pre>code` background transparent so that it doesn't obscure the text on the following line.


| Before | After |
| -------- | ---------|
| ![Screenshot from 2022-10-30 19-09-50](https://user-images.githubusercontent.com/128088/198897154-05683d16-97bb-48e3-a9a3-326fa40d5599.png) | ![Screenshot from 2022-10-30 19-09-58](https://user-images.githubusercontent.com/128088/198897162-c75d52c4-2910-4d59-bf93-a11cd44752cc.png) |