### PR TITLE
Append custom custom classes to labels

### DIFF
--- a/lib/govuk_design_system_formbuilder/elements/caption.rb
+++ b/lib/govuk_design_system_formbuilder/elements/caption.rb
@@ -2,6 +2,8 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Caption < Base
       include Traits::Localisation
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, text: nil, size: config.default_caption_size, **kwargs)
         super(builder, object_name, attribute_name)
@@ -14,10 +16,14 @@ module GOVUKDesignSystemFormBuilder
       def html
         return unless active?
 
-        tag.span(@text, class: @size_class, **@html_attributes)
+        tag.span(@text, **attributes(@html_attributes))
       end
 
     private
+
+      def options
+        { class: @size_class }
+      end
 
       def active?
         @text.present?
@@ -28,13 +34,9 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def size_class(size)
-        case size
-        when 'xl' then %(#{brand}-caption-xl)
-        when 'l'  then %(#{brand}-caption-l)
-        when 'm'  then %(#{brand}-caption-m)
-        else
-          fail ArgumentError, "invalid size '#{size}', must be xl, l or m"
-        end
+        fail ArgumentError, "invalid size '#{size}', must be xl, l or m" unless size.in?(%w(xl l m))
+
+        %(#{brand}-caption-#{size})
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/hint.rb
+++ b/lib/govuk_design_system_formbuilder/elements/hint.rb
@@ -4,6 +4,8 @@ module GOVUKDesignSystemFormBuilder
       using PrefixableArray
 
       include Traits::Localisation
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, value: nil, text: nil, content: nil, radio: false, checkbox: false, **kwargs)
         super(builder, object_name, attribute_name)
@@ -27,7 +29,7 @@ module GOVUKDesignSystemFormBuilder
       def html
         return unless active?
 
-        tag.div(**hint_options, **@html_attributes) { hint_body }
+        tag.div(**attributes(@html_attributes)) { hint_body }
       end
 
       def hint_id
@@ -38,7 +40,7 @@ module GOVUKDesignSystemFormBuilder
 
     private
 
-      def hint_options
+      def options
         { class: classes, id: hint_id }
       end
 

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -5,6 +5,8 @@ module GOVUKDesignSystemFormBuilder
 
       include Traits::Caption
       include Traits::Localisation
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, text: nil, value: nil, size: nil, hidden: false, radio: false, checkbox: false, tag: nil, link_errors: true, content: nil, caption: nil, **kwargs)
         super(builder, object_name, attribute_name)
@@ -44,7 +46,7 @@ module GOVUKDesignSystemFormBuilder
     private
 
       def label
-        @builder.label(@attribute_name, **options, **@html_attributes) do
+        @builder.label(@attribute_name, **attributes(@html_attributes)) do
           @content || safe_join([caption, @text])
         end
       end
@@ -63,7 +65,7 @@ module GOVUKDesignSystemFormBuilder
         {
           value: @value,
           for: field_id(link_errors: @link_errors),
-          class: %w(label).prefix(brand).push(@size_class, @weight_class, radio_class, checkbox_class).compact
+          class: classes
         }
       end
 
@@ -71,28 +73,22 @@ module GOVUKDesignSystemFormBuilder
         caption_element.html unless [@radio, @checkbox].any?
       end
 
-      def radio_class
-        return unless @radio
-
-        %(#{brand}-radios__label)
-      end
-
-      def checkbox_class
-        return unless @checkbox
-
-        %(#{brand}-checkboxes__label)
+      def classes
+        build_classes(
+          %(label),
+          @size_class,
+          @weight_class,
+          %(radios__label) => @radio,
+          %(checkboxes__label) => @checkbox,
+        ).prefix(brand)
       end
 
       def size_class(size)
-        case size
-        when 'xl' then %(#{brand}-label--xl)
-        when 'l'  then %(#{brand}-label--l)
-        when 'm'  then %(#{brand}-label--m)
-        when 's'  then %(#{brand}-label--s)
-        when nil  then nil
-        else
-          fail "invalid size '#{size}', must be xl, l, m, s or nil"
-        end
+        return nil if size.blank?
+
+        fail "invalid size '#{size}', must be xl, l, m, s or nil" unless size.in?(%w(xl l m s))
+
+        %(label--#{size})
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/label.rb
+++ b/lib/govuk_design_system_formbuilder/elements/label.rb
@@ -84,7 +84,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def size_class(size)
-        return nil if size.blank?
+        return if size.blank?
 
         fail "invalid size '#{size}', must be xl, l, m, s or nil" unless size.in?(%w(xl l m s))
 

--- a/lib/govuk_design_system_formbuilder/elements/legend.rb
+++ b/lib/govuk_design_system_formbuilder/elements/legend.rb
@@ -1,8 +1,12 @@
 module GOVUKDesignSystemFormBuilder
   module Elements
     class Legend < Base
+      using PrefixableArray
+
       include Traits::Caption
       include Traits::Localisation
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
       def initialize(builder, object_name, attribute_name, text: nil, size: config.default_legend_size, hidden: false, tag: config.default_legend_tag, caption: nil, content: nil, **kwargs)
         super(builder, object_name, attribute_name)
@@ -33,7 +37,19 @@ module GOVUKDesignSystemFormBuilder
       def legend
         return unless active?
 
-        tag.legend(legend_content, class: classes, **@html_attributes)
+        tag.legend(legend_content, **attributes(@html_attributes))
+      end
+
+      def options
+        { class: classes }
+      end
+
+      def classes
+        build_classes(
+          %(fieldset__legend),
+          @size_class,
+          %(visually-hidden) => @hidden
+        ).prefix(brand)
       end
 
       def legend_content
@@ -48,20 +64,10 @@ module GOVUKDesignSystemFormBuilder
         [supplied_text, localised_text(:legend), @attribute_name&.capitalize].find(&:presence)
       end
 
-      def classes
-        [%(#{brand}-fieldset__legend), @size_class, visually_hidden_class].compact
-      end
-
       def size_class(size)
-        if size.in?(%w(xl l m s))
-          %(#{brand}-fieldset__legend--#{size})
-        else
-          fail "invalid size '#{size}', must be xl, l, m or s"
-        end
-      end
+        fail "invalid size '#{size}', must be xl, l, m or s" unless size.in?(%w(xl l m s))
 
-      def visually_hidden_class
-        %(#{brand}-visually-hidden) if @hidden
+        %(fieldset__legend--#{size})
       end
 
       def heading_classes

--- a/spec/support/shared/shared_caption_examples.rb
+++ b/spec/support/shared/shared_caption_examples.rb
@@ -13,6 +13,15 @@ shared_examples 'a field that supports captions' do |captioned_element|
       end
     end
 
+    context 'when additional classes are provided' do
+      let(:classes) { %w(foo bar) }
+      subject { builder.send(*args, caption: { text: caption_text }.merge(class: classes)) }
+
+      specify 'the caption should have the custom classes' do
+        expect(subject).to have_tag('.govuk-caption-m', with: { class: classes }, text: caption_text)
+      end
+    end
+
     context 'when additional HTML attributes are provided' do
       let(:html_attributes) { { focusable: 'false', dir: 'rtl' } }
       subject { builder.send(*args, **caption_container, caption: caption_args.merge(html_attributes)) }

--- a/spec/support/shared/shared_hint_examples.rb
+++ b/spec/support/shared/shared_hint_examples.rb
@@ -20,11 +20,20 @@ shared_examples 'a field that supports hints' do
       expect(input_aria_describedby).to include(hint_id)
     end
 
+    context 'when additional classes are provided' do
+      let(:classes) { %w(foo bar) }
+      subject { builder.send(*args, hint: { text: hint_text }.merge(class: classes)) }
+
+      specify 'the hint should have the custom classes' do
+        expect(subject).to have_tag('.govuk-hint', with: { class: classes }, text: hint_text)
+      end
+    end
+
     context 'when additional HTML attributes are provided' do
       let(:html_attributes) { { focusable: 'false', dir: 'rtl' } }
       subject { builder.send(*args, hint: { text: hint_text }.merge(html_attributes)) }
 
-      specify 'the label should have the custom HTML attributes' do
+      specify 'the hint should have the custom HTML attributes' do
         expect(subject).to have_tag('.govuk-hint', with: html_attributes, text: hint_text)
       end
     end

--- a/spec/support/shared/shared_label_examples.rb
+++ b/spec/support/shared/shared_label_examples.rb
@@ -71,6 +71,15 @@ shared_examples 'a field that supports labels' do
     end
   end
 
+  context 'when additional classes are provided' do
+    let(:classes) { %w(foo bar) }
+    subject { builder.send(*args, label: { text: label_text }.merge(class: classes)) }
+
+    specify 'the label should have the custom classes' do
+      expect(subject).to have_tag('.govuk-label', with: { class: classes }, text: label_text)
+    end
+  end
+
   context 'when additional HTML attributes are provided' do
     let(:html_attributes) { { focusable: 'false', dir: 'rtl' } }
     subject { builder.send(*args, label: { text: label_text }.merge(html_attributes)) }

--- a/spec/support/shared/shared_legend_examples.rb
+++ b/spec/support/shared/shared_legend_examples.rb
@@ -77,6 +77,15 @@ shared_examples 'a field that supports a fieldset with legend' do
         end
       end
 
+      context 'when additional classes are provided' do
+        let(:classes) { %w(foo bar) }
+        subject { builder.send(*args, legend: { text: legend_text }.merge(class: classes)) }
+
+        specify 'the legend should have the custom classes' do
+          expect(subject).to have_tag('.govuk-fieldset__legend', with: { class: classes }, text: legend_text)
+        end
+      end
+
       context 'when additional HTML attributes are provided' do
         let(:html_attributes) { { focusable: 'false', lang: 'fr' } }
         subject { builder.send(*args, legend: { text: legend_text }.merge(html_attributes)) }


### PR DESCRIPTION
Before, custom classes passed in the `label` hash would override any existing classes.

For example:

```erb
<%= form_with model: @model do |f| %>
  <%= f.govuk_text_area :details, label: { text: "Some details", class: "special-class" } %>
<% end %>
```

would output:

```html
<!-- form markup --!>

<label for="model-details-field" class="special-class">
  Some details
</label>

<!-- form markup --!>
```

Taking into consideration how the rest of the library behaves, this behvaiour was unexpected and meant users would need to explicitly provide default label classes.

This change makes use of the `HTMLAttributes` and `HTMLClasses` traits so that label elements build classes as usual —except any custom classes are appended.

For example:

```erb
<%= form_with model: @model do |f| %>
  <%= f.govuk_text_area :details, label: { text: "Some details", class: "special-class" } %>
<% end %>
```

would now output:

```html
<!-- form markup --!>

<label for="model-details-field" class="govuk-label special-class">
  Some details
</label>

<!-- form markup --!?
```

This change in behaviour will affect users of the gem who are customising label classes but _don't_ want default classes to be applied.

I'm not sure if that is something we need to worry about though, since the form builder is intended to build GOV.UK (or other brand) forms.