### PR TITLE
GOV.UK Frontend 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk_design_system_formbuilder?logo=rubygems)](https://rubygems.org/gems/govuk_design_system_formbuilder)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/110136fb22341d3ba646/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-formbuilder/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk-formbuilder/blob/main/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.3.1-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.4.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.4-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-2.7.6%20%20%E2%95%B1%203.0.4%20%20%E2%95%B1%203.1.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -29,7 +29,7 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 4.3.1
+        | 4.4.0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^4.3.1",
+        "govuk-frontend": "^4.4.0",
         "sass": "^1.54.9"
       }
     },
@@ -106,9 +106,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
-      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
+      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -283,9 +283,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.1.tgz",
-      "integrity": "sha512-uD0KVFds7drOwLEvfp4zRBOXuHCxkWLYDQcYvlbG+2baZ9po2TGZz8WjfzhfueYjo9+Uwk+bM0NQT6g4cg/Q+A=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
+      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA=="
     },
     "immutable": {
       "version": "4.1.0",

--- a/guide/package.json
+++ b/guide/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^4.3.1",
+    "govuk-frontend": "^4.4.0",
     "sass": "^1.54.9"
   }
 }

--- a/lib/govuk_design_system_formbuilder/elements/error_summary.rb
+++ b/lib/govuk_design_system_formbuilder/elements/error_summary.rb
@@ -18,14 +18,16 @@ module GOVUKDesignSystemFormBuilder
         return unless object_has_errors?
 
         tag.div(**attributes(@html_attributes)) do
-          safe_join([title, summary])
+          tag.div(role: "alert") do
+            safe_join([title, summary])
+          end
         end
       end
 
     private
 
       def title
-        tag.h2(@title, id: summary_title_id, class: summary_class('title'))
+        tag.h2(@title, class: summary_class('title'))
       end
 
       def summary
@@ -110,10 +112,6 @@ module GOVUKDesignSystemFormBuilder
         end
       end
 
-      def summary_title_id
-        'error-summary-title'
-      end
-
       def object_has_errors?
         @builder.object.errors.any?
       end
@@ -121,13 +119,9 @@ module GOVUKDesignSystemFormBuilder
       def options
         {
           class: classes,
-          role: 'alert',
           data: {
             module: %(#{brand}-error-summary)
           },
-          aria: {
-            labelledby: [summary_title_id.presence]
-          }
         }
       end
 

--- a/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/error_summary_spec.rb
@@ -20,19 +20,18 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       specify 'the error summary should have a title' do
         expect(subject).to have_tag(
           'h2',
-          with: { id: 'error-summary-title', class: 'govuk-error-summary__title' }
+          with: { class: 'govuk-error-summary__title' }
         )
       end
 
       specify 'the error summary should have the correct accessibility attributes' do
-        expect(subject).to have_tag(
-          'div',
-          with: {
-            class: 'govuk-error-summary',
-            role: 'alert',
-            'data-module' => 'govuk-error-summary'
-          }
-        )
+        expected_attributes = { class: 'govuk-error-summary', 'data-module' => 'govuk-error-summary' }
+
+        expect(subject).to have_tag('div', with: expected_attributes) do
+          with_tag('div', with: { role: 'alert' }) do
+            with_tag('ul', with: { class: 'govuk-error-summary__list' })
+          end
+        end
       end
 
       describe 'error messages' do


### PR DESCRIPTION
GOV.UK Frontend [was released](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0) earlier today.

It looks like the vast majority of the changes are in the JavaScript and don't apply to this gem.

The ones that do are in the error summary; the following suggestions have been implemented 7ee5ce140c9f3ddc6.

> * Remove `aria-labelledby="error-summary-title"` and `role="alert"` from the
>   parent element (govuk-error-summary)
> * Add a div wrapper around the contents of govuk-error-summary with the
>   attribute `role="alert"`
> * Remove `id="error-summary-title"` from the error summary h2
>   (`govuk-error-summary__title`)
