### PR TITLE
Remove unneeded `x` from localisation regexp

### DIFF
--- a/lib/govuk_design_system_formbuilder/traits/localisation.rb
+++ b/lib/govuk_design_system_formbuilder/traits/localisation.rb
@@ -3,7 +3,7 @@ module GOVUKDesignSystemFormBuilder
     module Localisation
       # starts with an letter that is followed by other word characters or
       # spaces, zero or more times
-      BASE_NAME_REGEXP = %r{[[:alpha:]](?:[\w\s]*)}x.freeze
+      BASE_NAME_REGEXP = %r{[[:alpha:]](?:[\w\s]*)}.freeze
 
     private
 


### PR DESCRIPTION
This regexp was previously split over several lines with comments explaining what was going on. It was since simplified but the x wasn't removed.

Thanks @misaka for spotting this!
