### PR TITLE
Remove `[0-9]*` pattern from numeric text example

### DIFF
--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -12,7 +12,6 @@ module Examples
       <<~SNIPPET
         = f.govuk_text_field :account_number,
         label: { text: "Account number" },
-        pattern: "[0-9]*",
         inputmode: "numeric"
       SNIPPET
     end


### PR DESCRIPTION
Using the pattern attribute is no longer advised in the design system.
