### PR TITLE
Upgrade to Ruby `3.2.0` and bump versions to latest minor release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.6'
+          ruby-version: '3.0.5'
 
       - name: Install gems
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7.6', '3.0.4', '3.1.2']
+        ruby: ['3.0.5', '3.1.3', '3.2.0']
         rails: ['6.1.7', '7.0.4']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.1.1'
+          ruby-version: '3.1.3'
 
       - name: Install gems
         env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk_design_system_formbuilder)](https://github.com/DFE-Digital/govuk-formbuilder/blob/main/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.4.1-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.4-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-2.7.6%20%20%E2%95%B1%203.0.4%20%20%E2%95%B1%203.1.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This library provides an easy-to-use form builder for the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/govuk_design_system_formbuilder.gemspec
+++ b/govuk_design_system_formbuilder.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("html-attributes-utils", "~> 0.9", ">= 0.9.2")
 
   exact_rails_version = ENV.key?("RAILS_VERSION")
-  rails_version = ENV.fetch("RAILS_VERSION") { "6.1.5" }
+  rails_version = ENV.fetch("RAILS_VERSION") { "6.1.7" }
 
   %w(actionview activemodel activesupport).each do |lib|
     s.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -47,11 +47,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.1.2
+        | 3.2.0
+        br
+        | 3.1.3
         br
         | 3.0.4
-        br
-        | 2.7.6
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br


### PR DESCRIPTION
Ruby `3.2.0` is scheduled to be released tomorrow.

We aim to support the latest three major versions of Ruby, which will be `3.2.0`, `3.1.3` and `3.0.5`.

Support for Ruby 2.7 will be dropped. Most projects should have already upgraded to newer versions and the process is quite straightforward so this shouldn't be too problematic for users.

## Final things to do before merging

* [x] Switch `-rc1` for the final release version
