### PR TITLE
Remove classes argument throughout

### DIFF
--- a/guide/content/form-elements/submit.slim
+++ b/guide/content/form-elements/submit.slim
@@ -24,7 +24,7 @@ p.govuk-body
   code: warning_button)
 
 == render('/partials/example.*',
-  caption: 'Generating a submit button with custom class',
+  caption: 'Generating a submit button with a custom class',
   code: custom_classes_button)
 
 == render('/partials/example.*',

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -43,3 +43,14 @@ $x-govuk-brand-colour: #28a;
   display: inline-block;
   padding: govuk-spacing(2) govuk-spacing(3);
 }
+
+.big-purple-button {
+  background: govuk-colour("purple");
+  border-radius: .3em;
+  padding: .4em 2em;
+  font-weight: bold;
+
+  &:hover {
+    background: govuk-tint(govuk-colour("purple"), 10%);
+  }
+}

--- a/guide/lib/examples/submit.rb
+++ b/guide/lib/examples/submit.rb
@@ -13,7 +13,7 @@ module Examples
     end
 
     def custom_classes_button
-      "= f.govuk_submit 'Special button', classes: 'special-button-class'"
+      "= f.govuk_submit 'Big purple button', class: 'big-purple-button'"
     end
 
     def submit_button_without_double_click_prevention

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -24,7 +24,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -76,7 +75,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -129,7 +127,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -180,7 +177,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -230,7 +226,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -281,7 +276,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param prefix_text [String] the text placed before the input. No prefix will be added if left +nil+
     # @param suffix_text [String] the text placed after the input. No suffix will be added if left +nil+
@@ -339,7 +333,6 @@ module GOVUKDesignSystemFormBuilder
     # @param rows [Integer] sets the initial number of rows
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +textarea+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +textarea+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
@@ -389,7 +382,6 @@ module GOVUKDesignSystemFormBuilder
     # @option label kwargs [Hash] additional arguments are applied as attributes on the +label+ element
     # @param options [Hash] Options hash passed through to Rails' +collection_select+ helper
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-collection_select Rails collection_select (called by govuk_collection_select)
@@ -447,7 +439,6 @@ module GOVUKDesignSystemFormBuilder
     # @option label hidden [Boolean] control the visability of the label. Hidden labels will stil be read by screenreaders
     # @option label kwargs [Hash] additional arguments are applied as attributes on the +label+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] build the contents of the select element manually for exact control
     # @see https://api.rubyonrails.org/classes/ActionView/Helpers/FormOptionsHelper.html#method-i-select Rails select (called by govuk_collection_select)
@@ -494,7 +485,6 @@ module GOVUKDesignSystemFormBuilder
     # @param small [Boolean] controls whether small radio buttons are used instead of regular-sized ones
     # @param bold_labels [Boolean] controls whether the radio button labels are bold
     # @param include_hidden [Boolean] controls whether a hidden field is inserted to allow for empty submissions
-    # @param classes [Array,String] Classes to add to the radio button container.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
     # @option legend tag [Symbol,String] the tag used for the fieldset's header, defaults to +h1+.
@@ -538,7 +528,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('Which category do you belong to?') }
     #
-    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: nil, classes: nil, include_hidden: config.default_collection_radio_buttons_include_hidden, form_group: {}, &block)
+    def govuk_collection_radio_buttons(attribute_name, collection, value_method, text_method = nil, hint_method = nil, hint: {}, legend: {}, caption: {}, inline: false, small: false, bold_labels: nil, include_hidden: config.default_collection_radio_buttons_include_hidden, form_group: {}, **kwargs, &block)
       Elements::Radios::Collection.new(
         self,
         object_name,
@@ -553,9 +543,9 @@ module GOVUKDesignSystemFormBuilder
         inline: inline,
         small: small,
         bold_labels: bold_labels,
-        classes: classes,
         form_group: form_group,
         include_hidden: include_hidden,
+        **kwargs,
         &block
       ).html
     end
@@ -585,10 +575,8 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] a block of HTML that will be used to populate the fieldset
-    # @param classes [Array,String] Classes to add to the radio button container.
     # @see https://design-system.service.gov.uk/components/radios/ GOV.UK Radios
     # @see https://design-system.service.gov.uk/styles/typography/#headings-with-captions Headings with captions
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -610,8 +598,8 @@ module GOVUKDesignSystemFormBuilder
     #      = f.govuk_radio_button :burger_id, :regular, label: { text: 'Hamburger' }, link_errors: true
     #      = f.govuk_radio_button :burger_id, :cheese, label: { text: 'Cheeseburger' }
     #
-    def govuk_radio_buttons_fieldset(attribute_name, hint: {}, legend: {}, caption: {}, inline: false, small: false, classes: nil, form_group: {}, &block)
-      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, inline: inline, small: small, classes: classes, form_group: form_group, &block).html
+    def govuk_radio_buttons_fieldset(attribute_name, hint: {}, legend: {}, caption: {}, inline: false, small: false, form_group: {}, **kwargs, &block)
+      Containers::RadioButtonsFieldset.new(self, object_name, attribute_name, hint: hint, legend: legend, caption: caption, inline: inline, small: small, form_group: form_group, **kwargs, &block).html
     end
 
     # Generates a radio button
@@ -671,7 +659,6 @@ module GOVUKDesignSystemFormBuilder
     # @option hint text [String] the hint text
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param small [Boolean] controls whether small check boxes are used instead of regular-sized ones
-    # @param classes [Array,String] Classes to add to the checkbox container.
     # @param legend [NilClass,Hash,Proc] options for configuring the legend. Legend will be omitted if +nil+.
     # @option legend text [String] the fieldset legend's text content
     # @option legend size [String] the size of the fieldset legend font, can be +xl+, +l+, +m+ or +s+
@@ -682,7 +669,6 @@ module GOVUKDesignSystemFormBuilder
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param include_hidden [Boolean] controls whether a hidden field is inserted to allow for empty submissions
     # @param block [Block] any HTML passed in will be injected into the fieldset, after the hint and before the checkboxes
@@ -703,7 +689,7 @@ module GOVUKDesignSystemFormBuilder
     #    legend: { text: 'What do you want in your sandwich?', size: 'm' },
     #    hint: { text: "If it isn't listed here, tough luck" },
     #    inline: false,
-    #    classes: 'app-overflow-scroll',
+    #    class: 'app-overflow-scroll',
     #
     # @example A collection of check boxes for types of bread
     #  = f.govuk_collection_check_boxes :bread,
@@ -721,7 +707,7 @@ module GOVUKDesignSystemFormBuilder
     #    :name,
     #    legend: -> { tag.h3('What kind of sandwich do you want?') }
     #
-    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, classes: nil, form_group: {}, include_hidden: config.default_collection_check_boxes_include_hidden, &block)
+    def govuk_collection_check_boxes(attribute_name, collection, value_method, text_method, hint_method = nil, hint: {}, legend: {}, caption: {}, small: false, form_group: {}, include_hidden: config.default_collection_check_boxes_include_hidden, **kwargs, &block)
       Elements::CheckBoxes::Collection.new(
         self,
         object_name,
@@ -734,9 +720,9 @@ module GOVUKDesignSystemFormBuilder
         legend: legend,
         caption: caption,
         small: small,
-        classes: classes,
         form_group: form_group,
         include_hidden: include_hidden,
+        **kwargs,
         &block
       ).html
     end
@@ -762,11 +748,9 @@ module GOVUKDesignSystemFormBuilder
     # @option caption text [String] the caption text
     # @option caption size [String] the size of the caption, can be +xl+, +l+ or +m+. Defaults to +m+
     # @option caption kwargs [Hash] additional arguments are applied as attributes on the caption +span+ element
-    # @param classes [Array,String] Classes to add to the checkbox container.
     # @param form_group [Hash] configures the form group
     # @param multiple [Boolean] when true adds a +[]+ suffix the +name+ of the automatically-generated hidden field
     #   (ie. <code>project[invoice_attributes][]</code>). When false, no +[]+ suffix is added (ie. <code>project[accepted]</code>)
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] a block of HTML that will be used to populate the fieldset
     # @return [ActiveSupport::SafeBuffer] HTML output
@@ -781,7 +765,7 @@ module GOVUKDesignSystemFormBuilder
     #    = f.govuk_check_box :desired_filling, :lemonade, label: { text: 'Lemonade' }, link_errors: true
     #    = f.govuk_check_box :desired_filling, :fizzy_orange, label: { text: 'Fizzy orange' }
     #
-    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint: {}, small: false, classes: nil, form_group: {}, multiple: true, &block)
+    def govuk_check_boxes_fieldset(attribute_name, legend: {}, caption: {}, hint: {}, small: false, form_group: {}, multiple: true, **kwargs, &block)
       Containers::CheckBoxesFieldset.new(
         self,
         object_name,
@@ -790,9 +774,9 @@ module GOVUKDesignSystemFormBuilder
         legend: legend,
         caption: caption,
         small: small,
-        classes: classes,
         form_group: form_group,
         multiple: multiple,
+        **kwargs,
         &block
       ).html
     end
@@ -861,7 +845,6 @@ module GOVUKDesignSystemFormBuilder
     # @param text [String,Proc] the button text. When a +Proc+ is provided its contents will be rendered within the button element
     # @param warning [Boolean] makes the button red ({https://design-system.service.gov.uk/components/button/#warning-buttons warning}) when true
     # @param secondary [Boolean] makes the button grey ({https://design-system.service.gov.uk/components/button/#secondary-buttons secondary}) when true
-    # @param classes [Array,String] Classes to add to the submit button
     # @param prevent_double_click [Boolean] adds JavaScript to safeguard the
     #   form from being submitted more than once
     # @param validate [Boolean] adds the formnovalidate to the submit button when true, this disables all
@@ -886,8 +869,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_submit "Proceed", prevent_double_click: true do
     #     = link_to 'Cancel', some_other_path, class: 'govuk-button__secondary'
     #
-    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, classes: nil, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, **kwargs, &block)
-      Elements::Submit.new(self, text, warning: warning, secondary: secondary, classes: classes, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, **kwargs, &block).html
+    def govuk_submit(text = config.default_submit_button_text, warning: false, secondary: false, prevent_double_click: true, validate: config.default_submit_validate, disabled: false, **kwargs, &block)
+      Elements::Submit.new(self, text, warning: warning, secondary: secondary, prevent_double_click: prevent_double_click, validate: validate, disabled: disabled, **kwargs, &block).html
     end
 
     # Generates three inputs for the +day+, +month+ and +year+ components of a date
@@ -914,7 +897,6 @@ module GOVUKDesignSystemFormBuilder
     # @param omit_day [Boolean] do not render a day input, only capture month and year
     # @param maxlength_enabled [Boolean] adds maxlength attribute to day, month and year inputs (2, 2, and 4, respectively)
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input group
@@ -1021,7 +1003,6 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @option kwargs [Hash] kwargs additional arguments are applied as attributes to the +input+ element
     # @param form_group [Hash] configures the form group
-    # @option form_group classes [Array,String] sets the form group's classes
     # @option form_group kwargs [Hash] additional attributes added to the form group
     # @param block [Block] arbitrary HTML that will be rendered between the hint and the input
     #

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes.rb
@@ -1,15 +1,18 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class CheckBoxes < Base
-      def initialize(builder, small:, classes: nil)
+      include Traits::HTMLClasses
+      include Traits::HTMLAttributes
+
+      def initialize(builder, small:, **kwargs)
         super(builder, nil, nil)
 
-        @small   = small
-        @classes = classes
+        @small = small
+        @html_attributes = kwargs
       end
 
       def html(&block)
-        tag.div(**options, &block)
+        tag.div(**attributes(@html_attributes), &block)
       end
 
     private
@@ -22,15 +25,10 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        combine_references(%(#{brand}-checkboxes), small_class, custom_classes)
-      end
-
-      def small_class
-        %(#{brand}-checkboxes--small) if @small
-      end
-
-      def custom_classes
-        Array.wrap(@classes)
+        build_classes(
+          %(#{brand}-checkboxes),
+          %(#{brand}-checkboxes--small) => @small,
+        )
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/check_boxes_fieldset.rb
@@ -4,18 +4,18 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Error
       include Traits::Hint
 
-      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, classes:, form_group:, multiple:, &block)
+      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, small:, form_group:, multiple:, **kwargs, &block)
         fail LocalJumpError, 'no block given' unless block_given?
 
         super(builder, object_name, attribute_name, &block)
 
-        @legend        = legend
-        @caption       = caption
-        @hint          = hint
-        @small         = small
-        @classes       = classes
-        @form_group    = form_group
-        @multiple      = multiple
+        @legend          = legend
+        @caption         = caption
+        @hint            = hint
+        @small           = small
+        @form_group      = form_group
+        @multiple        = multiple
+        @html_attributes = kwargs
       end
 
       def html
@@ -47,7 +47,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def checkboxes
-        Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
+        Containers::CheckBoxes.new(@builder, small: @small, **@html_attributes).html do
           @block_content
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/form_group.rb
+++ b/lib/govuk_design_system_formbuilder/containers/form_group.rb
@@ -1,33 +1,28 @@
 module GOVUKDesignSystemFormBuilder
   module Containers
     class FormGroup < Base
-      def initialize(builder, object_name, attribute_name, classes: nil, **kwargs)
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
+
+      def initialize(builder, object_name, attribute_name, **kwargs)
         super(builder, object_name, attribute_name)
 
-        @classes         = classes
         @html_attributes = kwargs
       end
 
       def html(&block)
-        tag.div(class: classes, **@html_attributes, &block)
+        tag.div(**attributes(@html_attributes), &block)
       end
 
     private
 
-      def classes
-        combine_references(form_group_class, error_class, custom_classes)
-      end
-
-      def form_group_class
-        %(#{brand}-form-group)
-      end
-
-      def error_class
-        %(#{brand}-form-group--error) if has_errors?
-      end
-
-      def custom_classes
-        Array.wrap(@classes)
+      def options
+        {
+          class: build_classes(
+            %(#{brand}-form-group),
+            %(#{brand}-form-group--error) => has_errors?
+          )
+        }
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radio_buttons_fieldset.rb
@@ -4,18 +4,18 @@ module GOVUKDesignSystemFormBuilder
       include Traits::Hint
       include Traits::Error
 
-      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, inline:, small:, classes:, form_group:, &block)
+      def initialize(builder, object_name, attribute_name, hint:, legend:, caption:, inline:, small:, form_group:, **kwargs, &block)
         fail LocalJumpError, 'no block given' unless block_given?
 
         super(builder, object_name, attribute_name, &block)
 
-        @inline        = inline
-        @small         = small
-        @legend        = legend
-        @caption       = caption
-        @hint          = hint
-        @classes       = classes
-        @form_group    = form_group
+        @inline          = inline
+        @small           = small
+        @legend          = legend
+        @caption         = caption
+        @hint            = hint
+        @form_group      = form_group
+        @html_attributes = kwargs
       end
 
       def html
@@ -37,7 +37,7 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def radios
-        Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
+        Containers::Radios.new(@builder, inline: @inline, small: @small, **@html_attributes).html do
           @block_content
         end
       end

--- a/lib/govuk_design_system_formbuilder/containers/radios.rb
+++ b/lib/govuk_design_system_formbuilder/containers/radios.rb
@@ -2,17 +2,19 @@ module GOVUKDesignSystemFormBuilder
   module Containers
     class Radios < Base
       include Traits::Hint
+      include Traits::HTMLAttributes
+      include Traits::HTMLClasses
 
-      def initialize(builder, inline:, small:, classes:)
+      def initialize(builder, inline:, small:, **kwargs)
         super(builder, nil, nil)
 
-        @inline  = inline
-        @small   = small
-        @classes = classes
+        @inline          = inline
+        @small           = small
+        @html_attributes = kwargs
       end
 
       def html(&block)
-        tag.div(**options, &block)
+        tag.div(**attributes(@html_attributes), &block)
       end
 
     private
@@ -25,19 +27,11 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        combine_references(%(#{brand}-radios), inline_class, small_class, custom_classes)
-      end
-
-      def inline_class
-        %(#{brand}-radios--inline) if @inline
-      end
-
-      def small_class
-        %(#{brand}-radios--small)  if @small
-      end
-
-      def custom_classes
-        Array.wrap(@classes)
+        build_classes(
+          %(#{brand}-radios),
+          %(#{brand}-radios--inline) => @inline,
+          %(#{brand}-radios--small) => @small,
+        )
       end
     end
   end

--- a/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/check_boxes/collection.rb
@@ -6,20 +6,20 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, legend:, caption:, small:, classes:, form_group:, include_hidden:, hint_method: nil, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint:, legend:, caption:, small:, form_group:, include_hidden:, hint_method: nil, **kwargs, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection     = collection
-          @value_method   = value_method
-          @text_method    = text_method
-          @hint_method    = hint_method
-          @small          = small
-          @legend         = legend
-          @caption        = caption
-          @hint           = hint
-          @classes        = classes
-          @form_group     = form_group
-          @include_hidden = include_hidden
+          @collection      = collection
+          @value_method    = value_method
+          @text_method     = text_method
+          @hint_method     = hint_method
+          @small           = small
+          @legend          = legend
+          @caption         = caption
+          @hint            = hint
+          @form_group      = form_group
+          @include_hidden  = include_hidden
+          @html_attributes = kwargs
         end
 
         def html
@@ -41,7 +41,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def check_boxes
-          Containers::CheckBoxes.new(@builder, small: @small, classes: @classes).html do
+          Containers::CheckBoxes.new(@builder, small: @small, **@html_attributes).html do
             collection
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
+++ b/lib/govuk_design_system_formbuilder/elements/radios/collection.rb
@@ -6,22 +6,22 @@ module GOVUKDesignSystemFormBuilder
         include Traits::Hint
         include Traits::Supplemental
 
-        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint:, legend:, caption:, inline:, small:, bold_labels:, classes:, form_group:, include_hidden:, &block)
+        def initialize(builder, object_name, attribute_name, collection, value_method:, text_method:, hint_method:, hint:, legend:, caption:, inline:, small:, bold_labels:, form_group:, include_hidden:, **kwargs, &block)
           super(builder, object_name, attribute_name, &block)
 
-          @collection     = collection
-          @value_method   = value_method
-          @text_method    = text_method
-          @hint_method    = hint_method
-          @inline         = inline
-          @small          = small
-          @legend         = legend
-          @caption        = caption
-          @hint           = hint
-          @classes        = classes
-          @form_group     = form_group
-          @include_hidden = include_hidden
-          @bold_labels    = (bold_labels.nil? && auto_bold_labels?) || bold_labels
+          @collection      = collection
+          @value_method    = value_method
+          @text_method     = text_method
+          @hint_method     = hint_method
+          @inline          = inline
+          @small           = small
+          @legend          = legend
+          @caption         = caption
+          @hint            = hint
+          @form_group      = form_group
+          @include_hidden  = include_hidden
+          @bold_labels     = (bold_labels.nil? && auto_bold_labels?) || bold_labels
+          @html_attributes = kwargs
         end
 
         def html
@@ -48,7 +48,7 @@ module GOVUKDesignSystemFormBuilder
         end
 
         def radios
-          Containers::Radios.new(@builder, inline: @inline, small: @small, classes: @classes).html do
+          Containers::Radios.new(@builder, inline: @inline, small: @small, **@html_attributes).html do
             safe_join(collection)
           end
         end

--- a/lib/govuk_design_system_formbuilder/elements/submit.rb
+++ b/lib/govuk_design_system_formbuilder/elements/submit.rb
@@ -2,9 +2,10 @@ module GOVUKDesignSystemFormBuilder
   module Elements
     class Submit < Base
       using PrefixableArray
+      include Traits::HTMLClasses
       include Traits::HTMLAttributes
 
-      def initialize(builder, text, warning:, secondary:, classes:, prevent_double_click:, validate:, disabled:, **kwargs, &block)
+      def initialize(builder, text, warning:, secondary:, prevent_double_click:, validate:, disabled:, **kwargs, &block)
         super(builder, nil, nil)
 
         fail ArgumentError, 'buttons can be warning or secondary' if warning && secondary
@@ -13,7 +14,6 @@ module GOVUKDesignSystemFormBuilder
         @prevent_double_click = prevent_double_click
         @warning              = warning
         @secondary            = secondary
-        @classes              = classes
         @validate             = validate
         @disabled             = disabled
         @html_attributes      = kwargs
@@ -56,34 +56,19 @@ module GOVUKDesignSystemFormBuilder
           disabled: @disabled,
           class: classes,
           data: {
-            module: %(#{brand}-button),
-            'prevent-double-click': @prevent_double_click
+            'module' => %(#{brand}-button),
+            'prevent-double-click' => @prevent_double_click
           }.select { |_k, v| v.present? }
         }
       end
 
       def classes
-        %w(button)
-          .prefix(brand)
-          .push(warning_class, secondary_class, disabled_class, custom_classes)
-          .flatten
-          .compact
-      end
-
-      def warning_class
-        %(#{brand}-button--warning) if @warning
-      end
-
-      def secondary_class
-        %(#{brand}-button--secondary) if @secondary
-      end
-
-      def disabled_class
-        %(#{brand}-button--disabled) if @disabled
-      end
-
-      def custom_classes
-        Array.wrap(@classes)
+        build_classes(
+          "button",
+          "button--warning" => @warning,
+          "button--secondary" => @secondary,
+          "button--disabled" => @disabled,
+        ).prefix(brand)
       end
     end
   end

--- a/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
+++ b/spec/govuk_design_system_formbuilder/builder/submit_spec.rb
@@ -72,7 +72,7 @@ describe GOVUKDesignSystemFormBuilder::FormBuilder do
       end
 
       context 'classes' do
-        subject { builder.send(*args.push('Create'), classes: %w(custom-class--one custom-class--two)) }
+        subject { builder.send(*args.push('Create'), class: %w(custom-class--one custom-class--two)) }
 
         specify 'button should have the custom class' do
           expect(subject).to have_tag('button', with: { class: %w(govuk-button custom-class--one custom-class--two) })

--- a/spec/support/shared/shared_custom_class_examples.rb
+++ b/spec/support/shared/shared_custom_class_examples.rb
@@ -1,6 +1,6 @@
 shared_examples 'a field that supports custom classes' do
   let(:block_content) { -> { %(You there, fill it up with petroleum distillate, and re-vulcanize my tires, post-haste!) } }
-  subject { builder.send(*args, classes: custom_classes, &block_content) }
+  subject { builder.send(*args, class: custom_classes, &block_content) }
 
   context 'when classes are supplied in an array' do
     let(:custom_classes) { %w(custom-class--one custom-class--two) }

--- a/spec/support/shared/shared_form_group_examples.rb
+++ b/spec/support/shared/shared_form_group_examples.rb
@@ -5,7 +5,7 @@ shared_examples 'a field that contains a customisable form group' do
     let(:default_class) { %w(govuk-form-group) }
 
     subject do
-      builder.send(*args, form_group: { classes: custom_classes }) { builder.tag.span(block_content) }
+      builder.send(*args, form_group: { class: custom_classes }) { builder.tag.span(block_content) }
     end
 
     context 'classes passed in as an array' do


### PR DESCRIPTION
Now we are using [html-attributes-utils](https://github.com/DFE-Digital/html-attributes-utils) we can safely merge the `class` param without worrying about overwriting defaults.

html-attributes-utils [maintains a list of mergeable HTML attributes](https://github.com/DFE-Digital/html-attributes-utils/blob/main/lib/html_attributes_utils.rb#L12) (those that contain an array of space-separated values like `class`, `rel`, etc) so will append/overwrite accordingly.

This means we can completely lose `classes:` and treat `class:` like any other HTML attribute, by passing it through via `**kwargs`.

The opportunity was also taken to tidy up some class-building methods [so they're using `build_classes`](https://github.com/DFE-Digital/govuk-formbuilder/blob/main/lib/govuk_design_system_formbuilder/traits/html_classes.rb#L8) instead of manually constructing an array.