### PR TITLE
Add `extra_letter_spacing` argument to text inputs

### DIFF
--- a/guide/content/form-elements/text-input.slim
+++ b/guide/content/form-elements/text-input.slim
@@ -145,4 +145,13 @@ p.govuk-body
       intended to enter. For example, a telephone number input needn’t be the
       full width of the page when it might only be 11 digits long.
 
+== render('/partials/example.*',
+  caption: "Inputs with extra spacing between letters",
+  code: text_field_with_extra_letter_spacing) do
+
+  p.govuk-body
+    | When asking for long codes, references or phone numbers we can make the
+      text in the field more readable by adding some extra spacing between
+      characters.
+
 == render('/partials/related-info.*', links: text_field_info)

--- a/guide/lib/examples/text_input.rb
+++ b/guide/lib/examples/text_input.rb
@@ -49,5 +49,23 @@ module Examples
           suffix_text: 'per kg'
       SNIPPET
     end
+
+    def text_field_with_extra_letter_spacing
+      <<~SNIPPET
+        = f.govuk_text_field :national_insurance_number_without_spacing,
+          label: { size: 'm', text: 'What is your National Insurance number?' },
+          caption: { text: 'Without extra letter spacing' },
+          width: 10,
+          value: 'QQ123456A',
+          extra_letter_spacing: false
+
+        = f.govuk_text_field :national_insurance_number_with_spacing,
+          label: { size: 'm', text: 'What is your National Insurance number?' },
+          caption: { text: 'With extra letter spacing' },
+          width: 10,
+          value: 'QQ123456A',
+          extra_letter_spacing: true
+      SNIPPET
+    end
   end
 end

--- a/guide/lib/helpers/person.rb
+++ b/guide/lib/helpers/person.rb
@@ -9,7 +9,9 @@ class Person
     :job_title,
     :postcode,
     :account_number,
-    :price_per_kg
+    :price_per_kg,
+    :national_insurance_number_with_spacing,
+    :national_insurance_number_without_spacing,
   )
 
   # width examples

--- a/lib/govuk_design_system_formbuilder/builder.rb
+++ b/lib/govuk_design_system_formbuilder/builder.rb
@@ -12,6 +12,8 @@ module GOVUKDesignSystemFormBuilder
     #
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -50,8 +52,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_text_field :callsign,
     #     label: -> { tag.h3('Call-sign') }
     #
-    def govuk_text_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::Text.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_text_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, extra_letter_spacing: false, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Text.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +tel+
@@ -63,6 +65,8 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -102,8 +106,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_phone_field :work_number,
     #     label: -> { tag.h3('Work number') }
     #
-    def govuk_phone_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_phone_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, extra_letter_spacing: false, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Phone.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +email+
@@ -115,6 +119,8 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -152,8 +158,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_email_field :personal_email,
     #     label: -> { tag.h3('Personal email address') }
     #
-    def govuk_email_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::Email.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_email_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, extra_letter_spacing: false, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Email.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +password+
@@ -165,6 +171,8 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -201,8 +209,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_password_field :passcode,
     #     label: -> { tag.h3('What is your secret pass code?') }
     #
-    def govuk_password_field(attribute_name, hint: {}, label: {}, width: nil, form_group: {}, caption: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::Password.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_password_field(attribute_name, hint: {}, label: {}, width: nil, extra_letter_spacing: false, form_group: {}, caption: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Password.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +url+
@@ -214,6 +222,8 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -251,8 +261,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :work_website,
     #     label: -> { tag.h3("Enter your company's website") }
     #
-    def govuk_url_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::URL.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_url_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, extra_letter_spacing: false, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::URL.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a input of type +number+
@@ -264,6 +274,8 @@ module GOVUKDesignSystemFormBuilder
     # @option hint kwargs [Hash] additional arguments are applied as attributes to the hint
     # @param width [Integer,String] sets the width of the input, can be +2+, +3+ +4+, +5+, +10+ or +20+ characters
     #   or +one-quarter+, +one-third+, +one-half+, +two-thirds+ or +full+ width of the container
+    # @param extra_letter_spacing [Boolean] when true adds space between characters to increase the readability of
+    #   sequences of letters and numbers. Defaults to +false+.
     # @param label [Hash,Proc] configures or sets the associated label content
     # @option label text [String] the label text
     # @option label size [String] the size of the label font, can be +xl+, +l+, +m+, +s+ or nil
@@ -304,8 +316,8 @@ module GOVUKDesignSystemFormBuilder
     #   = f.govuk_url_field :personal_best_over_100m,
     #     label: -> { tag.h3("How many seconds does it take you to run 100m?") }
     #
-    def govuk_number_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
-      Elements::Inputs::Number.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
+    def govuk_number_field(attribute_name, hint: {}, label: {}, caption: {}, width: nil, extra_letter_spacing: false, form_group: {}, prefix_text: nil, suffix_text: nil, **kwargs, &block)
+      Elements::Inputs::Number.new(self, object_name, attribute_name, hint: hint, label: label, caption: caption, width: width, extra_letter_spacing: extra_letter_spacing, form_group: form_group, prefix_text: prefix_text, suffix_text: suffix_text, **kwargs, &block).html
     end
 
     # Generates a +textarea+ element with a label, optional hint. Also offers

--- a/lib/govuk_design_system_formbuilder/traits/input.rb
+++ b/lib/govuk_design_system_formbuilder/traits/input.rb
@@ -1,17 +1,18 @@
 module GOVUKDesignSystemFormBuilder
   module Traits
     module Input
-      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, prefix_text:, suffix_text:, width:, form_group:, **kwargs, &block)
+      def initialize(builder, object_name, attribute_name, hint:, label:, caption:, prefix_text:, suffix_text:, width:, extra_letter_spacing:, form_group:, **kwargs, &block)
         super(builder, object_name, attribute_name, &block)
 
-        @width           = width
-        @label           = label
-        @caption         = caption
-        @hint            = hint
-        @prefix_text     = prefix_text
-        @suffix_text     = suffix_text
-        @html_attributes = kwargs
-        @form_group      = form_group
+        @width                = width
+        @label                = label
+        @caption              = caption
+        @hint                 = hint
+        @prefix_text          = prefix_text
+        @suffix_text          = suffix_text
+        @html_attributes      = kwargs
+        @form_group           = form_group
+        @extra_letter_spacing = extra_letter_spacing
       end
 
       def html
@@ -53,11 +54,15 @@ module GOVUKDesignSystemFormBuilder
       end
 
       def classes
-        [%(#{brand}-input)].push(width_classes, error_classes).compact
+        [%(#{brand}-input)].push(width_classes, error_classes, extra_letter_spacing_classes).compact
       end
 
       def error_classes
         %(#{brand}-input--error) if has_errors?
+      end
+
+      def extra_letter_spacing_classes
+        %(#{brand}-input--extra-letter-spacing) if @extra_letter_spacing
       end
 
       def width_classes

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -97,6 +97,14 @@ shared_examples 'a regular input' do |method_identifier, field_type|
     end
   end
 
+  describe 'extra letter spacing' do
+    subject { builder.send(method, :name, extra_letter_spacing: true) }
+
+    specify 'has extra letter spacing class on the input element' do
+      expect(subject).to have_tag('input', with: { class: 'govuk-input--extra-letter-spacing' })
+    end
+  end
+
   describe 'affixes' do
     let(:prefix_text) { '£' }
     let(:suffix_text) { 'per item' }

--- a/spec/support/shared/shared_text_field_examples.rb
+++ b/spec/support/shared/shared_text_field_examples.rb
@@ -103,6 +103,14 @@ shared_examples 'a regular input' do |method_identifier, field_type|
     specify 'has extra letter spacing class on the input element' do
       expect(subject).to have_tag('input', with: { class: 'govuk-input--extra-letter-spacing' })
     end
+
+    context 'when false' do
+      subject { builder.send(method, :name, extra_letter_spacing: false) }
+
+      specify 'no element with the class is rendered' do
+        expect(subject).not_to have_tag('.govuk-input--extra-letter-spacing')
+      end
+    end
   end
 
   describe 'affixes' do


### PR DESCRIPTION
When true, the `extra_letter_spacing` argument adds the class 'govuk-input--extra-letter-spacing' to the text input element. It is available for all text fields and defaults to false.

This behaviour was added in [GOV.UK Design System version 4.6.0](https://github.com/alphagov/govuk-frontend/pull/2230).

* [ ] add an example to the guide
